### PR TITLE
fix: Android UI TestsのAAR欠損を根本解消

### DIFF
--- a/.github/workflows/android-ui-tests.yml
+++ b/.github/workflows/android-ui-tests.yml
@@ -76,13 +76,6 @@ jobs:
           java-version: "17"
           cache: gradle
 
-      - name: Cache Gradle configuration cache (ui)
-        if: steps.shard.outputs.run_tests == 'true'
-        uses: actions/cache@v5
-        with:
-          path: android/.gradle/configuration-cache
-          key: ${{ runner.os }}-android-config-cache-ui-shard-${{ matrix.shard_index }}-${{ github.sha }}-${{ hashFiles('android/**/*.gradle*', 'android/gradle.properties', 'android/settings.gradle.kts', 'android/gradle/libs.versions.toml') }}
-
       - name: Enable KVM
         if: steps.shard.outputs.run_tests == 'true'
         run: |
@@ -101,7 +94,7 @@ jobs:
           working-directory: android
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          script: ./gradlew :app:connectedDebugAndroidTest --no-daemon --configuration-cache -Pandroid.testInstrumentationRunnerArguments.class=${{ steps.shard.outputs.class_argument }}
+          script: ./gradlew :app:connectedDebugAndroidTest --no-daemon -Pandroid.testInstrumentationRunnerArguments.class=${{ steps.shard.outputs.class_argument }}
 
       - name: Upload Android UI test report
         if: always() && steps.shard.outputs.run_tests == 'true'
@@ -123,4 +116,4 @@ jobs:
             exit 0
           fi
           echo "- 割当クラス: \`${{ steps.shard.outputs.class_display }}\`" >> "${GITHUB_STEP_SUMMARY}"
-          echo "- 再現コマンド: \`cd android && ./gradlew :app:connectedDebugAndroidTest --no-daemon --configuration-cache -Pandroid.testInstrumentationRunnerArguments.class=${{ steps.shard.outputs.class_argument }}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "- 再現コマンド: \`cd android && ./gradlew :app:connectedDebugAndroidTest --no-daemon -Pandroid.testInstrumentationRunnerArguments.class=${{ steps.shard.outputs.class_argument }}\`" >> "${GITHUB_STEP_SUMMARY}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,7 @@ cd android && ./gradlew :tools:seed-generator:test --no-daemon
 - `Android UI Tests`（`.github/workflows/android-ui-tests.yml`）
   - `androidTest` をクラス単位2シャード実行
   - `pull_request`（path filter）/ `workflow_dispatch` / `schedule`
+  - `schedule` の同一SHA再実行で Configuration Cache が壊れる事例があるため、UIテストでは `--configuration-cache` を使わない
 - `Android Release`（`.github/workflows/android-release.yml`）
   - 署名済み `app-release.apk` を artifact / Release asset として公開
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- GitHub Actions `Android UI Tests`（`.github/workflows/android-ui-tests.yml`）の実行から `--configuration-cache` と `android/.gradle/configuration-cache` 復元を除外
+- `schedule` 実行で再発していた `:app:mergeDebugAndroidTestAssets` の AAR 欠損（`~/.gradle/caches/modules-2/.../*.aar (No such file or directory)`）を、壊れた Configuration Cache 再利用を断つことで根本解消
+
 ## [1.0.1] - 2026-02-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ adb shell am start -n com.anagram.analyzer/.MainActivity
 
 - `CI` ワークフロー: Android Unit Test / Build（PRはAndroid差分時のみ）
 - `Android UI Tests` ワークフロー: `androidTest` をクラス単位2シャードで実行
+  - 安定性優先のため UI テストでは `--configuration-cache` を利用しない（Unit/Build では利用）
 - `Android Release` ワークフロー: 署名済み `app-release.apk` を配布
 
 ## ライセンス

--- a/prompt.md
+++ b/prompt.md
@@ -81,6 +81,9 @@ cd android && ./gradlew :app:testDebugUnitTest
 # Android UI Test
 cd android && ./gradlew :app:connectedDebugAndroidTest
 
+# CIメモ
+# Android UI Tests（schedule含む）は安定性のため --configuration-cache を付けない
+
 # seed TSV生成
 python scripts/export_android_seed.py --xml ~/.jamdict/data/JMdict_e.gz --output android/app/src/main/assets/anagram_seed.tsv --min-len 2 --max-len 8
 

--- a/tasks.md
+++ b/tasks.md
@@ -90,6 +90,7 @@
 - [x] Android CI（Unit/Build/UI）で Gradle Configuration Cache を有効化し、`android/.gradle/configuration-cache` の保存・復元を追加。ローカル連続実行の `testDebugUnitTest --dry-run --no-daemon` 計測で 6.69s → 4.10s（再利用時、約39%短縮）を確認
 - [x] `Android UI Tests` の Configuration Cacheキーに `github.sha` を含め、古いコミットのキャッシュ再利用で発生する `mergeDebugAndroidTestAssets` 失敗（AAR欠損）を回避
 - [x] `MainScreenTest` の「システム戻るキー」検証を `onBackPressedDispatcher` ベースへ調整し、CIエミュレータでのタイムアウト（`ComposeTimeoutException`）を抑制
+- [x] `Android UI Tests` から `--configuration-cache` と `android/.gradle/configuration-cache` 復元を除外し、schedule 実行で再発していた `mergeDebugAndroidTestAssets`（AAR欠損）を根本解消
 - [ ] Android用CI/CDパイプライン完成
 - [ ] リリースビルド設定（署名、ProGuard/R8）
 - [ ] Google Play Store 公開準備
@@ -176,7 +177,7 @@
 | 4: UI実装 | 🟡 進行中 | メイン画面実装、候補詳細画面（漢字/意味のseed実データ表示 + 未収録語オンデマンド取得導線 + 共有ボタン/意味長押し選択）、ライト/ダーク切替、グラデーション背景/カード/カラーボタンによるUIカラー強化、上部左右/下部イラスト配置 + Pastel配色適用、候補一覧の50件上限制御、ランチャーアイコン適用（更新素材から再生成含む）、手動テスト可能な最小フロー、Compose UIテスト追加 |
 | 5: 辞書データ | 🟡 進行中 | seed変換/取込導線 + サイズ最適化（`max-len=8`）+ ライセンス表示 + 初回インポート計測ログ + 8/10投入時間比較 + 候補詳細オンデマンド取得/キャッシュ + JMdict XML→Room DB 変換ツール + `anagram_seed.db` 優先読込まで実施 |
 | 6: 追加機能 | 🟡 進行中 | DataStore によるテーマ設定永続化 + 入力履歴永続化 + 履歴折りたたみ表示 + 設定画面（文字数範囲/テーマ/追加辞書DL適用）まで実装 |
-| 7: CI/CD・リリース | 🟡 進行中 | Android UIテスト分離（2シャード）+ CI本体の差分判定でPR時のAndroid Unit/Build条件実行 + Android Unit/Build/UIでConfiguration Cache有効化（`android/.gradle/configuration-cache` 保存復元、ローカル連続計測で `testDebugUnitTest --dry-run` 6.69s→4.10s）に加え、UIテストのConfiguration Cacheキーへ `github.sha` を導入して古いコミットのキャッシュ再利用起因の失敗を抑制。debug APK artifact と GitHub Release向け署名済みAPK公開ワークフロー（dispatch自動タグ発行対応）も継続 |
+| 7: CI/CD・リリース | 🟡 進行中 | Android UIテスト分離（2シャード）+ CI本体の差分判定でPR時のAndroid Unit/Build条件実行 + Unit/BuildでConfiguration Cache有効化（`android/.gradle/configuration-cache` 保存復元、ローカル連続計測で `testDebugUnitTest --dry-run` 6.69s→4.10s）を維持。UIテストは schedule 環境でのAAR欠損再発を防ぐため `--configuration-cache` を無効化。debug APK artifact と GitHub Release向け署名済みAPK公開ワークフロー（dispatch自動タグ発行対応）も継続 |
 | 8: Pythonプロトタイプ撤去 | ✅ 完了 | Python CLI本体と関連CI/依存管理を削除し、Android単一実装に整理 |
 | 9: seed生成Kotlin/JVM移行 | ✅ 完了 | tools:seed-generator 実装（JmdictParser/Normalizer/TsvExporter/DbExporter/Main）、scripts/*.py削除、CI更新 |
 | 12: クイズ単語重みづけ | ✅ 完了 | JMdict re_pri による isCommon フラグ導入、DB version 4、一般語優先出題（フォールバック付き） |


### PR DESCRIPTION
## 概要
Android UI Tests の schedule 実行で再発していた `:app:mergeDebugAndroidTestAssets` 失敗を修正しました。

## 原因
- UIテストで `--configuration-cache` を有効化
- かつ `android/.gradle/configuration-cache` を `actions/cache` で復元
- schedule の同一SHA再実行で壊れた Configuration Cache が再利用され、依存 AAR 実体が見つからない状態（No such file or directory）が継続

## 対応（根本対策）
- `.github/workflows/android-ui-tests.yml` から UI テスト用の Configuration Cache 復元ステップを削除
- UI テスト実行コマンドから `--configuration-cache` を削除
- 再現コマンド表記も同様に更新

## 補足
- Unit / Build ジョブの Configuration Cache は維持（性能メリットを継続）
- ドキュメント更新: `AGENTS.md`, `CHANGELOG.md`, `README.md`, `tasks.md`

## 期待効果
- Android UI Tests（特に schedule）での AAR 欠損系フレークの再発防止
