### PR TITLE
[codex] Issue #40 クイズカードUIと出題回避を実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 **anagram-analyzer** は、ひらがな文字列を並べ替えて作れる日本語単語候補を返す Android アプリです。
 
 - 本実装: **Android版（Kotlin + Jetpack Compose）**
-- 補助ツール: **Python辞書変換スクリプト（seed生成用）**
+- 補助ツール: **Kotlin/JVM seed-generator（JMdict→TSV/DB生成）**
 - 旧 Python CLI プロトタイプ: **削除済み（2026-02-21）**
 
 ## 技術スタック
@@ -25,11 +25,11 @@
 | ビルド | Gradle (Kotlin DSL) |
 | CI | GitHub Actions（Android Unit/Build/UI/Release） |
 
-### 辞書生成スクリプト
+### 辞書生成ツール
 
 | カテゴリ | 技術 |
 |---------|------|
-| 言語 | Python 3 |
+| 言語 | Kotlin/JVM |
 | 入力 | JMdict XML (`.xml` / `.gz`) |
 | 出力 | `anagram_seed.tsv`, `anagram_seed.db` |
 
@@ -89,8 +89,8 @@ anagram-analyzer/
 ### `data/db/`
 
 - `AnagramEntry.kt`: アナグラム索引Entity（`sorted_key + word` 一意制約）
-- `AnagramDao.kt`: seed投入・キー検索・`getRandomEntry(minLen, maxLen)` ランダム取得
-- `AnagramDatabase.kt`: Room DB本体（`version 3`、Migration `1→2` / `2→3`）
+- `AnagramDao.kt`: seed投入・キー検索・文字数範囲件数/offset取得・一般語優先クイズ取得
+- `AnagramDatabase.kt`: Room DB本体（`version 5`、Migration `1→2` / `2→3` / `3→4` / `4→5`）
 - `CandidateDetailCacheEntry.kt` / `CandidateDetailCacheDao.kt`: 候補詳細キャッシュ
 
 ### `data/datastore/`
@@ -110,6 +110,7 @@ anagram-analyzer/
 
 ### `domain/model/`
 
+- `CharCard.kt`: クイズカードUI用データクラス（`id` / `char` / `isPlaced`）
 - `HiraganaNormalizer.kt`: NFKC正規化・カタカナ→ひらがな・ひらがな判定・アナグラムキー生成
 - `PreloadLogger.kt`: seed初期化ログ用 fun interface（`domain` 層に配置）
 
@@ -119,14 +120,14 @@ anagram-analyzer/
 - `SearchAnagramUseCase.kt`: アナグラム索引検索（`AnagramDao.lookupWords` ラッパー）
 - `LoadCandidateDetailUseCase.kt`: 候補詳細オンデマンド取得（`CandidateDetailLoader` ラッパー）
 - `ApplyAdditionalDictionaryUseCase.kt`: 追加辞書適用（投入件数・最終更新日時を返す）
-- `GenerateQuizUseCase.kt`: クイズ出題（ランダムエントリ取得 → 文字シャッフル → 正解リスト生成、`SearchAnagramUseCase` 再利用）
+- `GenerateQuizUseCase.kt`: クイズ出題（一般語優先ランダム取得 → 正解並びを避けたカード列生成 → 回避不能時は別問題へ切替）
 
 ### `ui/viewmodel/`
 
 - `MainUiState.kt`: UI状態 data class（flat構造 17フィールド）
 - `MainViewModel.kt`: UC4クラス + Store2 + Dispatcher を注入したViewModel（~343行）
-- `QuizUiState.kt`: クイズ画面UI状態 data class + `QuizPhase` enum（IDLE/LOADING/ANSWERING/CORRECT/INCORRECT）
-- `QuizViewModel.kt`: クイズフロー全体制御 @HiltViewModel（難易度選択・出題・回答判定・スコア管理）
+- `QuizUiState.kt`: クイズ画面UI状態 data class（`shuffledCards` / `answerSlots` / `selectedCardId` を含む）+ `QuizPhase` enum
+- `QuizViewModel.kt`: クイズフロー全体制御 @HiltViewModel（難易度選択・カード配置/移動・回答判定・スコア管理）
 
 ### `ui/screen/`
 
@@ -134,7 +135,7 @@ anagram-analyzer/
 - `CandidateDetailScreen.kt`: 候補詳細画面 Composable（`internal`）
 - `SettingsDialog.kt`: `AboutDialog` / `SettingsDialog` Composable（`internal`）
 - `ShareUtil.kt`: `shareCandidateDetail` ユーティリティ関数（`internal`）
-- `QuizScreen.kt`: クイズモード画面 Composable（難易度選択→問題→回答→正解/不正解フロー）
+- `QuizScreen.kt`: クイズモード画面 Composable（難易度選択→カードタップ回答→正解/不正解フロー、アニメーション/触覚付き）
 
 ## モジュール詳細（辞書生成ツール）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Issue #40 クイズカードタップ式入力UI**
+  - `domain/model/CharCard.kt` を追加し、カード単位の配置状態を表現可能に更新
+  - `ui/viewmodel/QuizViewModelTest.kt` にカード配置/移動イベントのテストを追加
+  - `domain/usecase/GenerateQuizUseCaseTest.kt` を追加し、正解そのまま出題の回避と別問題への切り替えを検証
+
 ### Changed
 
+- `QuizQuestion` を `shuffledCards` ベースへ更新し、`QuizUiState` を `shuffledCards` / `answerSlots` / `selectedCardId` 構成へ変更
+- `QuizViewModel` をカードタップ入力方式へ更新し、スロット配置・取り消し・入れ替えから回答判定できるよう変更
+- `QuizScreen` の回答UIをテキスト入力からカード選択グリッドへ刷新し、選択ハイライト・スロットハイライト・バウンスアニメーション・触覚フィードバックを追加
+- `GenerateQuizUseCase` を更新し、正解候補や `sortedKey` と同一の並びを出題しないようにし、回避不能時は別エントリへ切り替えるよう変更
 - GitHub Actions `Android UI Tests`（`.github/workflows/android-ui-tests.yml`）の実行から `--configuration-cache` と `android/.gradle/configuration-cache` 復元を除外
 - `schedule` 実行で再発していた `:app:mergeDebugAndroidTestAssets` の AAR 欠損（`~/.gradle/caches/modules-2/.../*.aar (No such file or directory)`）を、壊れた Configuration Cache 再利用を断つことで根本解消
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ cd android && ./gradlew :app:connectedDebugAndroidTest
 cd android && ./gradlew :app:lintDebug
 ```
 
+## クイズモード
+
+- 文字カードをタップして解答スロットへ並べるカード入力UIを実装しています。
+- 正解候補の並びそのものが問題文として出ないようにし、回避不能な問題は別の単語へ切り替えます。
+- スコア、連続正解数、最高連続正解数はアプリ内で保持されます。
+
 ## 辞書seed更新（開発者向け）
 
 Kotlin/JVM CLIツール（`tools:seed-generator`）で JMdict XML（`.xml` / `.gz`）から seed を生成します。
@@ -72,6 +78,8 @@ adb shell am start -n com.anagram.analyzer/.MainActivity
 - `りんご` → 候補に `りんご`
 - `リンゴ` → ひらがな正規化後に候補表示
 - `abc` → エラー表示
+- クイズモード → カードをタップして答えを完成できる
+- クイズモード → 正解候補そのままの並びが出題されない
 
 ## CI運用（要点）
 

--- a/android/app/src/main/java/com/anagram/analyzer/domain/model/CharCard.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/domain/model/CharCard.kt
@@ -1,0 +1,7 @@
+package com.anagram.analyzer.domain.model
+
+data class CharCard(
+    val id: Int,
+    val char: Char,
+    val isPlaced: Boolean,
+)

--- a/android/app/src/main/java/com/anagram/analyzer/domain/model/QuizQuestion.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/domain/model/QuizQuestion.kt
@@ -1,7 +1,7 @@
 package com.anagram.analyzer.domain.model
 
 data class QuizQuestion(
-    val shuffledChars: String,
+    val shuffledCards: List<CharCard>,
     val sortedKey: String,
     val correctWords: List<String>,
 )

--- a/android/app/src/main/java/com/anagram/analyzer/domain/usecase/GenerateQuizUseCase.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/domain/usecase/GenerateQuizUseCase.kt
@@ -1,9 +1,10 @@
 package com.anagram.analyzer.domain.usecase
 
 import com.anagram.analyzer.data.db.AnagramDao
+import com.anagram.analyzer.data.db.AnagramEntry
+import com.anagram.analyzer.domain.model.CharCard
 import com.anagram.analyzer.domain.model.QuizQuestion
 import javax.inject.Inject
-
 import kotlin.random.Random
 
 class GenerateQuizUseCase @Inject constructor(
@@ -15,27 +16,146 @@ class GenerateQuizUseCase @Inject constructor(
         val useCommon = commonCount > 0
         val count = if (useCommon) commonCount else anagramDao.countByLength(minLen, maxLen)
         if (count == 0) return null
-        val offset = Random.nextInt(count)
-        val entry = if (useCommon) {
-            anagramDao.getCommonEntryAtOffset(minLen, maxLen, offset)
-        } else {
-            anagramDao.getEntryAtOffset(minLen, maxLen, offset)
-        } ?: return null
+
+        for (offset in buildCandidateOffsets(count)) {
+            val entry = if (useCommon) {
+                anagramDao.getCommonEntryAtOffset(minLen, maxLen, offset)
+            } else {
+                anagramDao.getEntryAtOffset(minLen, maxLen, offset)
+            } ?: continue
+
+            val question = buildQuestion(entry)
+            if (question != null) return question
+        }
+
+        return null
+    }
+
+    private suspend fun buildQuestion(entry: AnagramEntry): QuizQuestion? {
         val correctWords = searchAnagramUseCase.execute(entry.sortedKey)
         if (correctWords.isEmpty()) return null
+
+        val prompt = buildPrompt(entry.sortedKey, correctWords) ?: return null
         return QuizQuestion(
-            shuffledChars = shuffle(entry.sortedKey),
+            shuffledCards = prompt.mapIndexed { index, char ->
+                CharCard(id = index, char = char, isPlaced = false)
+            },
             sortedKey = entry.sortedKey,
             correctWords = correctWords,
         )
     }
 
-    private fun shuffle(original: String, maxAttempts: Int = 10): String {
-        if (original.length <= 1) return original
-        repeat(maxAttempts) {
-            val shuffled = original.toList().shuffled().joinToString("")
-            if (shuffled != original) return shuffled
+    private fun buildCandidateOffsets(count: Int): List<Int> {
+        if (count <= EXHAUSTIVE_ENTRY_THRESHOLD) {
+            return (0 until count).shuffled()
         }
-        return original.toList().shuffled().joinToString("")
+
+        val offsets = linkedSetOf<Int>()
+        while (offsets.size < MAX_ENTRY_ATTEMPTS) {
+            offsets += Random.nextInt(count)
+        }
+        return offsets.toList()
+    }
+
+    private fun buildPrompt(sortedKey: String, correctWords: List<String>): String? {
+        if (sortedKey.length <= 1) return null
+
+        val forbiddenPrompts = correctWords.toHashSet().apply {
+            add(sortedKey)
+        }
+
+        repeat(MAX_SHUFFLE_ATTEMPTS) {
+            val shuffled = sortedKey.toList().shuffled().joinToString("")
+            if (shuffled !in forbiddenPrompts) return shuffled
+        }
+
+        return findPromptByPrefixSearch(sortedKey, forbiddenPrompts)
+    }
+
+    private fun findPromptByPrefixSearch(
+        sortedKey: String,
+        forbiddenPrompts: Set<String>,
+    ): String? {
+        val remainingCounts = sortedKey.groupingBy { it }.eachCount().toMutableMap()
+        val charOrder = remainingCounts.keys.sorted()
+        val forbiddenPrefixes = buildForbiddenPrefixes(forbiddenPrompts)
+        return searchPrompt(
+            prefix = StringBuilder(),
+            targetLength = sortedKey.length,
+            remainingCounts = remainingCounts,
+            charOrder = charOrder,
+            forbiddenPrefixes = forbiddenPrefixes,
+            forbiddenPrompts = forbiddenPrompts,
+        )
+    }
+
+    private fun searchPrompt(
+        prefix: StringBuilder,
+        targetLength: Int,
+        remainingCounts: MutableMap<Char, Int>,
+        charOrder: List<Char>,
+        forbiddenPrefixes: Set<String>,
+        forbiddenPrompts: Set<String>,
+    ): String? {
+        if (prefix.length == targetLength) {
+            val candidate = prefix.toString()
+            return candidate.takeIf { it !in forbiddenPrompts }
+        }
+
+        for (char in charOrder) {
+            val remaining = remainingCounts[char] ?: 0
+            if (remaining == 0) continue
+
+            remainingCounts[char] = remaining - 1
+            prefix.append(char)
+
+            val nextPrefix = prefix.toString()
+            val candidate = if (prefix.length < targetLength && nextPrefix !in forbiddenPrefixes) {
+                nextPrefix + buildRemainingChars(remainingCounts, charOrder)
+            } else {
+                searchPrompt(
+                    prefix = prefix,
+                    targetLength = targetLength,
+                    remainingCounts = remainingCounts,
+                    charOrder = charOrder,
+                    forbiddenPrefixes = forbiddenPrefixes,
+                    forbiddenPrompts = forbiddenPrompts,
+                )
+            }
+
+            if (candidate != null && candidate !in forbiddenPrompts) {
+                return candidate
+            }
+
+            prefix.deleteCharAt(prefix.lastIndex)
+            remainingCounts[char] = remaining
+        }
+
+        return null
+    }
+
+    private fun buildForbiddenPrefixes(forbiddenPrompts: Set<String>): Set<String> = buildSet {
+        forbiddenPrompts.forEach { word ->
+            for (index in 1 until word.length) {
+                add(word.substring(0, index))
+            }
+        }
+    }
+
+    private fun buildRemainingChars(
+        remainingCounts: Map<Char, Int>,
+        charOrder: List<Char>,
+    ): String = buildString {
+        charOrder.forEach { char ->
+            repeat(remainingCounts[char] ?: 0) {
+                append(char)
+            }
+        }
+    }
+
+    private companion object {
+        private const val EXHAUSTIVE_ENTRY_THRESHOLD = 128
+        private const val MAX_ENTRY_ATTEMPTS = 32
+        private const val MAX_SHUFFLE_ATTEMPTS = 24
     }
 }

--- a/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -39,6 +40,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -356,19 +358,22 @@ private fun CharCardGrid(
     selectedCardId: Int?,
     onCardTapped: (Int) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        cards.chunked(CARDS_PER_ROW).forEach { rowCards ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-            ) {
-                rowCards.forEach { card ->
-                    QuizCharCard(
-                        char = card.char.toString(),
-                        isSelected = selectedCardId == card.id,
-                        isPlaced = card.isPlaced,
-                        onClick = { onCardTapped(card.id) },
-                    )
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val cardsPerRow = calculateCardsPerRow(maxWidth)
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            cards.chunked(cardsPerRow).forEach { rowCards ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    rowCards.forEach { card ->
+                        QuizCharCard(
+                            char = card.char.toString(),
+                            isSelected = selectedCardId == card.id,
+                            isPlaced = card.isPlaced,
+                            onClick = { onCardTapped(card.id) },
+                        )
+                    }
                 }
             }
         }
@@ -383,20 +388,25 @@ private fun AnswerSlotGrid(
     onSlotTapped: (Int) -> Unit,
 ) {
     val cardsById = cards.associateBy { it.id }
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        answerSlots.chunked(CARDS_PER_ROW).forEachIndexed { rowIndex, rowSlots ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-            ) {
-                rowSlots.forEachIndexed { columnIndex, cardId ->
-                    val slotIndex = rowIndex * CARDS_PER_ROW + columnIndex
-                    AnswerSlot(
-                        value = cardId?.let { cardsById[it]?.char?.toString() }.orEmpty(),
-                        isFilled = cardId != null,
-                        isHighlighted = selectedCardId != null,
-                        onClick = { onSlotTapped(slotIndex) },
-                    )
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val cardsPerRow = calculateCardsPerRow(maxWidth)
+        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            answerSlots.chunked(cardsPerRow).forEachIndexed { rowIndex, rowSlots ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    rowSlots.forEachIndexed { columnIndex, cardId ->
+                        val slotIndex = rowIndex * cardsPerRow + columnIndex
+                        val isActionable = selectedCardId != null || cardId != null
+                        AnswerSlot(
+                            value = cardId?.let { cardsById[it]?.char?.toString() }.orEmpty(),
+                            isFilled = cardId != null,
+                            isHighlighted = selectedCardId != null,
+                            enabled = isActionable,
+                            onClick = { onSlotTapped(slotIndex) },
+                        )
+                    }
                 }
             }
         }
@@ -437,8 +447,8 @@ private fun QuizCharCard(
 
     Card(
         modifier = Modifier
-            .padding(horizontal = 6.dp)
-            .size(56.dp)
+            .padding(horizontal = QUIZ_CARD_HORIZONTAL_PADDING)
+            .size(QUIZ_CARD_SIZE)
             .graphicsLayer {
                 alpha = if (isPlaced) 0.4f else 1f
             }
@@ -467,6 +477,7 @@ private fun AnswerSlot(
     value: String,
     isFilled: Boolean,
     isHighlighted: Boolean,
+    enabled: Boolean,
     onClick: () -> Unit,
 ) {
     val containerColor by animateColorAsState(
@@ -504,14 +515,14 @@ private fun AnswerSlot(
 
     Card(
         modifier = Modifier
-            .padding(horizontal = 6.dp)
-            .size(56.dp)
+            .padding(horizontal = QUIZ_CARD_HORIZONTAL_PADDING)
+            .size(QUIZ_CARD_SIZE)
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale
             }
             .clip(RoundedCornerShape(16.dp))
-            .clickable(onClick = onClick),
+            .clickable(enabled = enabled, onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = containerColor),
         border = BorderStroke(width = borderWidth, color = borderColor),
         shape = RoundedCornerShape(16.dp),
@@ -594,4 +605,9 @@ private fun ResultSection(
     }
 }
 
-private const val CARDS_PER_ROW = 6
+private fun calculateCardsPerRow(maxWidth: Dp): Int =
+    (maxWidth / QUIZ_CARD_FOOTPRINT).toInt().coerceAtLeast(1)
+
+private val QUIZ_CARD_SIZE = 56.dp
+private val QUIZ_CARD_HORIZONTAL_PADDING = 6.dp
+private val QUIZ_CARD_FOOTPRINT = QUIZ_CARD_SIZE + (QUIZ_CARD_HORIZONTAL_PADDING * 2)

--- a/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
@@ -1,6 +1,13 @@
 package com.anagram.analyzer.ui.screen
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,20 +26,24 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.anagram.analyzer.domain.model.CharCard
 import com.anagram.analyzer.domain.model.QuizDifficulty
 import com.anagram.analyzer.ui.viewmodel.QuizPhase
 import com.anagram.analyzer.ui.viewmodel.QuizUiState
@@ -49,7 +60,8 @@ fun QuizScreen(
         onNavigateBack = onNavigateBack,
         onDifficultySelected = viewModel::onDifficultySelected,
         onStartQuiz = viewModel::onStartQuiz,
-        onInputAnswerChanged = viewModel::onInputAnswerChanged,
+        onCardTapped = viewModel::onCardTapped,
+        onSlotTapped = viewModel::onSlotTapped,
         onSubmitAnswer = viewModel::onSubmitAnswer,
         onNextQuestion = viewModel::onNextQuestion,
         onReset = viewModel::onReset,
@@ -62,7 +74,8 @@ fun QuizScreenContent(
     onNavigateBack: () -> Unit,
     onDifficultySelected: (QuizDifficulty) -> Unit,
     onStartQuiz: () -> Unit,
-    onInputAnswerChanged: (String) -> Unit,
+    onCardTapped: (Int) -> Unit,
+    onSlotTapped: (Int) -> Unit,
     onSubmitAnswer: () -> Unit,
     onNextQuestion: () -> Unit,
     onReset: () -> Unit,
@@ -80,7 +93,6 @@ fun QuizScreenContent(
             .background(gradient)
             .padding(16.dp),
     ) {
-        // ヘッダー
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -99,7 +111,6 @@ fun QuizScreenContent(
             }
         }
 
-        // スコアバー
         ScoreBar(
             score = state.score,
             streak = state.streak,
@@ -122,10 +133,12 @@ fun QuizScreenContent(
                 CircularProgressIndicator(modifier = Modifier.size(48.dp))
             }
             QuizPhase.ANSWERING -> AnsweringSection(
-                shuffledChars = state.question?.shuffledChars ?: "",
-                inputAnswer = state.inputAnswer,
+                shuffledCards = state.shuffledCards,
+                answerSlots = state.answerSlots,
+                selectedCardId = state.selectedCardId,
                 errorMessage = state.errorMessage,
-                onInputAnswerChanged = onInputAnswerChanged,
+                onCardTapped = onCardTapped,
+                onSlotTapped = onSlotTapped,
                 onSubmitAnswer = onSubmitAnswer,
             )
             QuizPhase.CORRECT -> ResultSection(
@@ -239,57 +252,284 @@ private fun IdleSection(
 
 @Composable
 private fun AnsweringSection(
-    shuffledChars: String,
-    inputAnswer: String,
+    shuffledCards: List<CharCard>,
+    answerSlots: List<Int?>,
+    selectedCardId: Int?,
     errorMessage: String?,
-    onInputAnswerChanged: (String) -> Unit,
+    onCardTapped: (Int) -> Unit,
+    onSlotTapped: (Int) -> Unit,
     onSubmitAnswer: () -> Unit,
 ) {
+    val haptic = LocalHapticFeedback.current
+    val selectedChar = shuffledCards.firstOrNull { it.id == selectedCardId }?.char
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Text(
-            text = "この文字を並べ替えてできる単語は？",
+            text = "カードをタップして単語を完成させてください",
             style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
         )
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-            ),
-            shape = RoundedCornerShape(16.dp),
-        ) {
-            Text(
-                text = shuffledChars,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 24.dp),
-                style = MaterialTheme.typography.headlineLarge,
-                fontWeight = FontWeight.Bold,
-                textAlign = TextAlign.Center,
-                letterSpacing = 8.sp,
+        Text(
+            text = selectedChar?.let { "選択中: 「$it」を置くマスをタップ" }
+                ?: "カードをタップで追加、マスをタップで取り消しや入れ替えができます",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+
+        QuizSectionCard(title = "もじカード") {
+            CharCardGrid(
+                cards = shuffledCards,
+                selectedCardId = selectedCardId,
+                onCardTapped = { cardId ->
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onCardTapped(cardId)
+                },
             )
         }
 
-        OutlinedTextField(
-            value = inputAnswer,
-            onValueChange = onInputAnswerChanged,
-            label = { Text("答えをひらがなで入力") },
-            isError = errorMessage != null,
-            supportingText = errorMessage?.let { { Text(it, color = MaterialTheme.colorScheme.error) } },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-        )
+        QuizSectionCard(title = "こたえ") {
+            AnswerSlotGrid(
+                cards = shuffledCards,
+                answerSlots = answerSlots,
+                selectedCardId = selectedCardId,
+                onSlotTapped = { slotIndex ->
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onSlotTapped(slotIndex)
+                },
+            )
+        }
+
+        if (errorMessage != null) {
+            Text(
+                text = errorMessage,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+            )
+        }
 
         Button(
             onClick = onSubmitAnswer,
-            enabled = inputAnswer.isNotBlank(),
+            enabled = answerSlots.isNotEmpty() && answerSlots.all { it != null },
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("こたえる", fontSize = 16.sp, fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+@Composable
+private fun QuizSectionCard(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.82f),
+        ),
+        shape = RoundedCornerShape(20.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun CharCardGrid(
+    cards: List<CharCard>,
+    selectedCardId: Int?,
+    onCardTapped: (Int) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        cards.chunked(CARDS_PER_ROW).forEach { rowCards ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                rowCards.forEach { card ->
+                    QuizCharCard(
+                        char = card.char.toString(),
+                        isSelected = selectedCardId == card.id,
+                        isPlaced = card.isPlaced,
+                        onClick = { onCardTapped(card.id) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnswerSlotGrid(
+    cards: List<CharCard>,
+    answerSlots: List<Int?>,
+    selectedCardId: Int?,
+    onSlotTapped: (Int) -> Unit,
+) {
+    val cardsById = cards.associateBy { it.id }
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        answerSlots.chunked(CARDS_PER_ROW).forEachIndexed { rowIndex, rowSlots ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                rowSlots.forEachIndexed { columnIndex, cardId ->
+                    val slotIndex = rowIndex * CARDS_PER_ROW + columnIndex
+                    AnswerSlot(
+                        value = cardId?.let { cardsById[it]?.char?.toString() }.orEmpty(),
+                        isFilled = cardId != null,
+                        isHighlighted = selectedCardId != null,
+                        onClick = { onSlotTapped(slotIndex) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuizCharCard(
+    char: String,
+    isSelected: Boolean,
+    isPlaced: Boolean,
+    onClick: () -> Unit,
+) {
+    val containerColor by animateColorAsState(
+        targetValue = when {
+            isSelected -> MaterialTheme.colorScheme.primary
+            isPlaced -> MaterialTheme.colorScheme.surfaceVariant
+            else -> MaterialTheme.colorScheme.secondaryContainer
+        },
+        label = "charCardColor",
+    )
+    val contentColor by animateColorAsState(
+        targetValue = when {
+            isSelected -> MaterialTheme.colorScheme.onPrimary
+            isPlaced -> MaterialTheme.colorScheme.onSurfaceVariant
+            else -> MaterialTheme.colorScheme.onSecondaryContainer
+        },
+        label = "charCardContentColor",
+    )
+    val borderColor by animateColorAsState(
+        targetValue = if (isSelected) {
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.9f)
+        } else {
+            MaterialTheme.colorScheme.outline.copy(alpha = if (isPlaced) 0.45f else 0.8f)
+        },
+        label = "charCardBorderColor",
+    )
+
+    Card(
+        modifier = Modifier
+            .padding(horizontal = 6.dp)
+            .size(56.dp)
+            .graphicsLayer {
+                alpha = if (isPlaced) 0.4f else 1f
+            }
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        border = BorderStroke(width = 2.dp, color = borderColor),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = char,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = contentColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AnswerSlot(
+    value: String,
+    isFilled: Boolean,
+    isHighlighted: Boolean,
+    onClick: () -> Unit,
+) {
+    val containerColor by animateColorAsState(
+        targetValue = when {
+            isFilled -> MaterialTheme.colorScheme.tertiaryContainer
+            isHighlighted -> MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
+            else -> MaterialTheme.colorScheme.surface
+        },
+        label = "answerSlotColor",
+    )
+    val borderColor by animateColorAsState(
+        targetValue = when {
+            isHighlighted -> MaterialTheme.colorScheme.primary
+            isFilled -> MaterialTheme.colorScheme.tertiary
+            else -> MaterialTheme.colorScheme.outline
+        },
+        label = "answerSlotBorderColor",
+    )
+    val borderWidth by animateDpAsState(
+        targetValue = when {
+            isHighlighted -> 3.dp
+            isFilled -> 2.dp
+            else -> 1.dp
+        },
+        label = "answerSlotBorderWidth",
+    )
+    val scale by animateFloatAsState(
+        targetValue = if (isFilled) 1f else 0.88f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+        ),
+        label = "answerSlotScale",
+    )
+
+    Card(
+        modifier = Modifier
+            .padding(horizontal = 6.dp)
+            .size(56.dp)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        border = BorderStroke(width = borderWidth, color = borderColor),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = value.ifEmpty { "・" },
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = if (isFilled) {
+                    MaterialTheme.colorScheme.onTertiaryContainer
+                } else {
+                    MaterialTheme.colorScheme.outline
+                },
+            )
         }
     }
 }
@@ -353,3 +593,5 @@ private fun ResultSection(
         }
     }
 }
+
+private const val CARDS_PER_ROW = 6

--- a/android/app/src/main/java/com/anagram/analyzer/ui/viewmodel/QuizUiState.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/viewmodel/QuizUiState.kt
@@ -1,5 +1,6 @@
 package com.anagram.analyzer.ui.viewmodel
 
+import com.anagram.analyzer.domain.model.CharCard
 import com.anagram.analyzer.domain.model.QuizDifficulty
 import com.anagram.analyzer.domain.model.QuizQuestion
 
@@ -8,7 +9,9 @@ enum class QuizPhase { IDLE, LOADING, ANSWERING, CORRECT, INCORRECT }
 data class QuizUiState(
     val phase: QuizPhase = QuizPhase.IDLE,
     val question: QuizQuestion? = null,
-    val inputAnswer: String = "",
+    val shuffledCards: List<CharCard> = emptyList(),
+    val answerSlots: List<Int?> = emptyList(),
+    val selectedCardId: Int? = null,
     val score: Int = 0,
     val streak: Int = 0,
     val bestStreak: Int = 0,

--- a/android/app/src/main/java/com/anagram/analyzer/ui/viewmodel/QuizViewModel.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/viewmodel/QuizViewModel.kt
@@ -3,8 +3,7 @@ package com.anagram.analyzer.ui.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.anagram.analyzer.data.datastore.QuizScoreStore
-import com.anagram.analyzer.domain.model.HiraganaNormalizer
-import com.anagram.analyzer.domain.model.NormalizationException
+import com.anagram.analyzer.domain.model.CharCard
 import com.anagram.analyzer.domain.model.QuizDifficulty
 import com.anagram.analyzer.domain.usecase.GenerateQuizUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,8 +51,84 @@ class QuizViewModel @Inject constructor(
         loadNextQuestion()
     }
 
-    fun onInputAnswerChanged(value: String) {
-        _uiState.update { it.copy(inputAnswer = value, errorMessage = null) }
+    fun onCardTapped(cardId: Int) {
+        updateAnsweringState { state ->
+            val card = state.shuffledCards.firstOrNull { it.id == cardId } ?: return@updateAnsweringState state
+
+            when {
+                card.isPlaced -> {
+                    state.copy(
+                        shuffledCards = updateCardPlacement(state.shuffledCards, cardId, isPlaced = false),
+                        answerSlots = clearCardFromSlots(state.answerSlots, cardId),
+                        selectedCardId = cardId,
+                        errorMessage = null,
+                    )
+                }
+                state.selectedCardId == cardId -> {
+                    state.copy(selectedCardId = null, errorMessage = null)
+                }
+                state.selectedCardId != null -> {
+                    state.copy(selectedCardId = cardId, errorMessage = null)
+                }
+                else -> {
+                    val firstEmptySlot = state.answerSlots.indexOfFirst { it == null }
+                    if (firstEmptySlot == -1) {
+                        state.copy(selectedCardId = cardId, errorMessage = null)
+                    } else {
+                        placeCardInSlot(state, cardId, firstEmptySlot, selectedCardId = null)
+                    }
+                }
+            }
+        }
+    }
+
+    fun onSlotTapped(slotIndex: Int) {
+        updateAnsweringState { state ->
+            if (slotIndex !in state.answerSlots.indices) return@updateAnsweringState state
+
+            val cardIdInSlot = state.answerSlots[slotIndex]
+            val selectedCardId = state.selectedCardId
+
+            when {
+                selectedCardId != null -> {
+                    val nextSlots = clearCardFromSlots(state.answerSlots, selectedCardId).toMutableList()
+                    val nextCards = updateCardPlacement(
+                        state.shuffledCards,
+                        selectedCardId,
+                        isPlaced = true,
+                    )
+
+                    if (cardIdInSlot != null) {
+                        nextSlots[slotIndex] = selectedCardId
+                        state.copy(
+                            shuffledCards = updateCardPlacement(nextCards, cardIdInSlot, isPlaced = false),
+                            answerSlots = nextSlots,
+                            selectedCardId = cardIdInSlot,
+                            errorMessage = null,
+                        )
+                    } else {
+                        nextSlots[slotIndex] = selectedCardId
+                        state.copy(
+                            shuffledCards = nextCards,
+                            answerSlots = nextSlots,
+                            selectedCardId = null,
+                            errorMessage = null,
+                        )
+                    }
+                }
+                cardIdInSlot != null -> {
+                    val nextSlots = state.answerSlots.toMutableList()
+                    nextSlots[slotIndex] = null
+                    state.copy(
+                        shuffledCards = updateCardPlacement(state.shuffledCards, cardIdInSlot, isPlaced = false),
+                        answerSlots = nextSlots,
+                        selectedCardId = cardIdInSlot,
+                        errorMessage = null,
+                    )
+                }
+                else -> state
+            }
+        }
     }
 
     fun onSubmitAnswer() {
@@ -61,17 +136,12 @@ class QuizViewModel @Inject constructor(
         val question = state.question ?: return
         if (state.phase != QuizPhase.ANSWERING) return
 
-        val inputRaw = state.inputAnswer.trim()
-        if (inputRaw.isEmpty()) return
-
-        val normalizedInput = try {
-            HiraganaNormalizer.normalizeHiragana(inputRaw)
-        } catch (_: NormalizationException) {
-            _uiState.update { it.copy(errorMessage = "ひらがなで入力してください") }
+        val answer = buildAnswer(state) ?: run {
+            _uiState.update { it.copy(errorMessage = "すべての文字を配置してください") }
             return
         }
 
-        val isCorrect = question.correctWords.any { it == normalizedInput }
+        val isCorrect = question.correctWords.any { it == answer }
 
         viewModelScope.launch(ioDispatcher) {
             if (isCorrect) {
@@ -105,18 +175,39 @@ class QuizViewModel @Inject constructor(
     private fun loadNextQuestion() {
         if (_uiState.value.phase == QuizPhase.LOADING) return
         val difficulty = _uiState.value.difficulty
-        _uiState.update { it.copy(phase = QuizPhase.LOADING, inputAnswer = "", errorMessage = null) }
+        _uiState.update {
+            it.copy(
+                phase = QuizPhase.LOADING,
+                question = null,
+                shuffledCards = emptyList(),
+                answerSlots = emptyList(),
+                selectedCardId = null,
+                errorMessage = null,
+            )
+        }
         viewModelScope.launch {
             try {
                 val question = withContext(ioDispatcher) {
                     generateQuizUseCase.execute(difficulty.minLen, difficulty.maxLen)
                 }
                 if (question != null) {
-                    _uiState.update { it.copy(phase = QuizPhase.ANSWERING, question = question) }
+                    _uiState.update {
+                        it.copy(
+                            phase = QuizPhase.ANSWERING,
+                            question = question,
+                            shuffledCards = question.shuffledCards,
+                            answerSlots = List(question.shuffledCards.size) { null },
+                            selectedCardId = null,
+                        )
+                    }
                 } else {
                     _uiState.update {
                         it.copy(
                             phase = QuizPhase.IDLE,
+                            question = null,
+                            shuffledCards = emptyList(),
+                            answerSlots = emptyList(),
+                            selectedCardId = null,
                             errorMessage = "出題できる単語が見つかりませんでした。難易度を変えてみてください。",
                         )
                     }
@@ -126,12 +217,76 @@ class QuizViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         phase = QuizPhase.IDLE,
+                        question = null,
+                        shuffledCards = emptyList(),
+                        answerSlots = emptyList(),
+                        selectedCardId = null,
                         errorMessage = "問題の取得に失敗しました: ${error.message ?: "原因不明"}",
                     )
                 }
             }
         }
     }
+
+    private fun updateAnsweringState(transform: (QuizUiState) -> QuizUiState) {
+        _uiState.update { state ->
+            if (state.phase != QuizPhase.ANSWERING) {
+                state
+            } else {
+                transform(state)
+            }
+        }
+    }
+
+    private fun placeCardInSlot(
+        state: QuizUiState,
+        cardId: Int,
+        slotIndex: Int,
+        selectedCardId: Int?,
+    ): QuizUiState {
+        val nextSlots = clearCardFromSlots(state.answerSlots, cardId).toMutableList()
+        nextSlots[slotIndex] = cardId
+        return state.copy(
+            shuffledCards = updateCardPlacement(state.shuffledCards, cardId, isPlaced = true),
+            answerSlots = nextSlots,
+            selectedCardId = selectedCardId,
+            errorMessage = null,
+        )
+    }
+
+    private fun buildAnswer(state: QuizUiState): String? {
+        if (state.answerSlots.any { it == null }) return null
+
+        val cardsById = state.shuffledCards.associateBy(CharCard::id)
+        val answer = StringBuilder()
+        state.answerSlots.forEach { cardId ->
+            val resolvedId = cardId ?: return null
+            val card = cardsById[resolvedId] ?: return null
+            answer.append(card.char)
+        }
+        return answer.toString()
+    }
+
+    private fun updateCardPlacement(
+        cards: List<CharCard>,
+        cardId: Int,
+        isPlaced: Boolean,
+    ): List<CharCard> = cards.map { card ->
+        if (card.id == cardId) {
+            card.copy(isPlaced = isPlaced)
+        } else {
+            card
+        }
+    }
+
+    private fun clearCardFromSlots(answerSlots: List<Int?>, cardId: Int): List<Int?> =
+        answerSlots.map { slotCardId ->
+            if (slotCardId == cardId) {
+                null
+            } else {
+                slotCardId
+            }
+        }
 
     private companion object {
         private const val POINTS_PER_CORRECT = 10

--- a/android/app/src/test/java/com/anagram/analyzer/domain/usecase/GenerateQuizUseCaseTest.kt
+++ b/android/app/src/test/java/com/anagram/analyzer/domain/usecase/GenerateQuizUseCaseTest.kt
@@ -1,0 +1,113 @@
+package com.anagram.analyzer.domain.usecase
+
+import com.anagram.analyzer.data.db.AnagramDao
+import com.anagram.analyzer.data.db.AnagramEntry
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GenerateQuizUseCaseTest {
+    @Test
+    fun 正解そのものの並びでは出題しない() = runTest {
+        val dao = FakeGenerateQuizAnagramDao(
+            entries = listOf(
+                AnagramEntry(sortedKey = "ごりん", word = "りんご", length = 3),
+            ),
+            wordsBySortedKey = mapOf(
+                "ごりん" to listOf("りんご", "ごりん"),
+            ),
+        )
+        val useCase = GenerateQuizUseCase(
+            anagramDao = dao,
+            searchAnagramUseCase = SearchAnagramUseCase(dao),
+        )
+
+        val question = useCase.execute(minLen = 3, maxLen = 3)
+
+        assertNotNull(question)
+        val prompt = question!!.shuffledCards.joinToString(separator = "") { it.char.toString() }
+        assertTrue(prompt !in question.correctWords)
+        assertTrue(prompt != question.sortedKey)
+    }
+
+    @Test
+    fun 回避不能な問題は別のエントリへ切り替える() = runTest {
+        val dao = FakeGenerateQuizAnagramDao(
+            entries = listOf(
+                AnagramEntry(sortedKey = "あい", word = "あい", length = 2),
+                AnagramEntry(sortedKey = "ごりん", word = "りんご", length = 3),
+            ),
+            wordsBySortedKey = mapOf(
+                "あい" to listOf("あい", "いあ"),
+                "ごりん" to listOf("りんご"),
+            ),
+        )
+        val useCase = GenerateQuizUseCase(
+            anagramDao = dao,
+            searchAnagramUseCase = SearchAnagramUseCase(dao),
+        )
+
+        val question = useCase.execute(minLen = 2, maxLen = 3)
+
+        assertNotNull(question)
+        assertEquals("ごりん", question!!.sortedKey)
+    }
+
+    @Test
+    fun 全て回避不能ならnullを返す() = runTest {
+        val dao = FakeGenerateQuizAnagramDao(
+            entries = listOf(
+                AnagramEntry(sortedKey = "あい", word = "あい", length = 2),
+            ),
+            wordsBySortedKey = mapOf(
+                "あい" to listOf("あい", "いあ"),
+            ),
+        )
+        val useCase = GenerateQuizUseCase(
+            anagramDao = dao,
+            searchAnagramUseCase = SearchAnagramUseCase(dao),
+        )
+
+        val question = useCase.execute(minLen = 2, maxLen = 2)
+
+        assertNull(question)
+    }
+
+    private class FakeGenerateQuizAnagramDao(
+        private val entries: List<AnagramEntry>,
+        private val wordsBySortedKey: Map<String, List<String>>,
+    ) : AnagramDao {
+        override suspend fun insertAll(entries: List<AnagramEntry>) = Unit
+
+        override suspend fun lookupWords(sortedKey: String): List<String> =
+            wordsBySortedKey[sortedKey].orEmpty()
+
+        override suspend fun count(): Long = entries.size.toLong()
+
+        override suspend fun countByLength(minLen: Int, maxLen: Int): Int =
+            filterEntries(minLen, maxLen, commonOnly = false).size
+
+        override suspend fun getEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? =
+            filterEntries(minLen, maxLen, commonOnly = false).getOrNull(offset)
+
+        override suspend fun countCommonByLength(minLen: Int, maxLen: Int): Int =
+            filterEntries(minLen, maxLen, commonOnly = true).size
+
+        override suspend fun getCommonEntryAtOffset(
+            minLen: Int,
+            maxLen: Int,
+            offset: Int,
+        ): AnagramEntry? = filterEntries(minLen, maxLen, commonOnly = true).getOrNull(offset)
+
+        private fun filterEntries(
+            minLen: Int,
+            maxLen: Int,
+            commonOnly: Boolean,
+        ): List<AnagramEntry> = entries.filter { entry ->
+            entry.length in minLen..maxLen && (!commonOnly || entry.isCommon)
+        }
+    }
+}

--- a/android/app/src/test/java/com/anagram/analyzer/ui/viewmodel/QuizViewModelTest.kt
+++ b/android/app/src/test/java/com/anagram/analyzer/ui/viewmodel/QuizViewModelTest.kt
@@ -1,10 +1,13 @@
 package com.anagram.analyzer.ui.viewmodel
 
+import com.anagram.analyzer.data.datastore.QuizScoreStore
 import com.anagram.analyzer.data.db.AnagramDao
 import com.anagram.analyzer.data.db.AnagramEntry
+import com.anagram.analyzer.domain.model.CharCard
 import com.anagram.analyzer.domain.model.QuizDifficulty
 import com.anagram.analyzer.domain.usecase.GenerateQuizUseCase
 import com.anagram.analyzer.domain.usecase.SearchAnagramUseCase
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -18,12 +21,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import com.anagram.analyzer.data.datastore.QuizScoreStore
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class QuizViewModelTest {
     @Test
-    fun スタート時にANSWERING状態になる() = runTest {
+    fun スタート時にANSWERING状態になりカードとスロットが初期化される() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         Dispatchers.setMain(dispatcher)
         try {
@@ -38,9 +40,75 @@ class QuizViewModelTest {
             advanceUntilIdle()
 
             assertEquals(QuizPhase.ANSWERING, viewModel.uiState.value.phase)
-            assertNull(viewModel.uiState.value.question?.shuffledChars?.let {
-                if (it.isEmpty()) "empty" else null
-            })
+            assertTrue(viewModel.uiState.value.shuffledCards.isNotEmpty())
+            assertEquals(
+                viewModel.uiState.value.shuffledCards.size,
+                viewModel.uiState.value.answerSlots.size,
+            )
+            assertTrue(viewModel.uiState.value.answerSlots.all { it == null })
+            assertNull(viewModel.uiState.value.selectedCardId)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun カードタップで先頭の空きスロットに配置される() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val viewModel = buildViewModel(
+                dao = FakeQuizAnagramDao(
+                    randomEntry = AnagramEntry(sortedKey = "ごりん", word = "りんご", length = 3),
+                    words = listOf("りんご"),
+                ),
+            )
+
+            viewModel.onStartQuiz()
+            advanceUntilIdle()
+
+            val cardId = viewModel.uiState.value.shuffledCards.first().id
+            viewModel.onCardTapped(cardId)
+
+            val state = viewModel.uiState.value
+            assertEquals(cardId, state.answerSlots.first())
+            assertTrue(state.shuffledCards.first { it.id == cardId }.isPlaced)
+            assertNull(state.selectedCardId)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun スロットタップでカードを取り外して任意の位置に移動できる() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val viewModel = buildViewModel(
+                dao = FakeQuizAnagramDao(
+                    randomEntry = AnagramEntry(sortedKey = "ごりん", word = "りんご", length = 3),
+                    words = listOf("りんご"),
+                ),
+            )
+
+            viewModel.onStartQuiz()
+            advanceUntilIdle()
+
+            val firstCardId = viewModel.uiState.value.shuffledCards.first().id
+            viewModel.onCardTapped(firstCardId)
+            viewModel.onSlotTapped(0)
+
+            var state = viewModel.uiState.value
+            assertEquals(firstCardId, state.selectedCardId)
+            assertEquals(null, state.answerSlots[0])
+            assertTrue(state.shuffledCards.first { it.id == firstCardId }.isPlaced.not())
+
+            viewModel.onSlotTapped(2)
+
+            state = viewModel.uiState.value
+            assertEquals(firstCardId, state.answerSlots[2])
+            assertNull(state.selectedCardId)
+            assertTrue(state.shuffledCards.first { it.id == firstCardId }.isPlaced)
         } finally {
             Dispatchers.resetMain()
         }
@@ -63,7 +131,7 @@ class QuizViewModelTest {
             viewModel.onStartQuiz()
             advanceUntilIdle()
 
-            viewModel.onInputAnswerChanged("りんご")
+            placeAnswer(viewModel, "りんご")
             viewModel.onSubmitAnswer()
             advanceUntilIdle()
 
@@ -92,7 +160,7 @@ class QuizViewModelTest {
             viewModel.onStartQuiz()
             advanceUntilIdle()
 
-            viewModel.onInputAnswerChanged("まちがい")
+            placeAnswer(viewModel, "ごんり")
             viewModel.onSubmitAnswer()
             advanceUntilIdle()
 
@@ -166,7 +234,7 @@ class QuizViewModelTest {
     private fun buildViewModel(
         dao: AnagramDao = FakeQuizAnagramDao(),
         quizScoreStore: QuizScoreStore = FakeQuizScoreStore(),
-        dispatcher: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.Main,
+        dispatcher: CoroutineDispatcher = Dispatchers.Main,
     ): QuizViewModel = QuizViewModel(
         generateQuizUseCase = GenerateQuizUseCase(
             anagramDao = dao,
@@ -176,7 +244,17 @@ class QuizViewModelTest {
         ioDispatcher = dispatcher,
     )
 
-    // ---- fakes ----
+    private fun placeAnswer(viewModel: QuizViewModel, answer: String) {
+        val availableCardIds = viewModel.uiState.value.shuffledCards
+            .groupBy(CharCard::char)
+            .mapValues { (_, cards) -> cards.map(CharCard::id).toMutableList() }
+
+        answer.forEach { char ->
+            val ids = availableCardIds[char] ?: error("テスト用カードが不足しています: $char")
+            val cardId = ids.removeAt(0)
+            viewModel.onCardTapped(cardId)
+        }
+    }
 
     private class FakeQuizAnagramDao(
         private val randomEntry: AnagramEntry? = null,
@@ -185,14 +263,23 @@ class QuizViewModelTest {
         override suspend fun insertAll(entries: List<AnagramEntry>) = Unit
         override suspend fun lookupWords(sortedKey: String): List<String> = words
         override suspend fun count(): Long = if (randomEntry != null) 1L else 0L
+
         override suspend fun countByLength(minLen: Int, maxLen: Int): Int =
             if (randomEntry != null && randomEntry.length in minLen..maxLen) 1 else 0
+
         override suspend fun getEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? =
             randomEntry?.takeIf { it.length in minLen..maxLen && offset == 0 }
+
         override suspend fun countCommonByLength(minLen: Int, maxLen: Int): Int =
             if (randomEntry != null && randomEntry.length in minLen..maxLen && randomEntry.isCommon) 1 else 0
-        override suspend fun getCommonEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? =
-            randomEntry?.takeIf { it.length in minLen..maxLen && it.isCommon && offset == 0 }
+
+        override suspend fun getCommonEntryAtOffset(
+            minLen: Int,
+            maxLen: Int,
+            offset: Int,
+        ): AnagramEntry? = randomEntry?.takeIf {
+            it.length in minLen..maxLen && it.isCommon && offset == 0
+        }
     }
 
     private class FakeQuizScoreStore(

--- a/android/app/src/test/java/com/anagram/analyzer/ui/viewmodel/QuizViewModelTest.kt
+++ b/android/app/src/test/java/com/anagram/analyzer/ui/viewmodel/QuizViewModelTest.kt
@@ -115,6 +115,41 @@ class QuizViewModelTest {
     }
 
     @Test
+    fun 埋まったスロットに選択中カードを置くと元のカードが選択状態になる() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val viewModel = buildViewModel(
+                dao = FakeQuizAnagramDao(
+                    randomEntry = AnagramEntry(sortedKey = "ごりん", word = "りんご", length = 3),
+                    words = listOf("りんご"),
+                ),
+            )
+
+            viewModel.onStartQuiz()
+            advanceUntilIdle()
+
+            val firstCardId = viewModel.uiState.value.shuffledCards[0].id
+            val secondCardId = viewModel.uiState.value.shuffledCards[1].id
+
+            viewModel.onCardTapped(firstCardId)
+            viewModel.onCardTapped(secondCardId)
+            viewModel.onSlotTapped(0)
+            viewModel.onSlotTapped(1)
+
+            val state = viewModel.uiState.value
+            assertNull(state.answerSlots[0])
+            assertEquals(firstCardId, state.answerSlots[1])
+            assertEquals(secondCardId, state.selectedCardId)
+            assertTrue(state.shuffledCards.first { it.id == firstCardId }.isPlaced)
+            assertTrue(state.shuffledCards.first { it.id == secondCardId }.isPlaced.not())
+            assertTrue(secondCardId !in state.answerSlots.filterNotNull())
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
     fun 正解時にスコアが加算されCORRECT状態になる() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         Dispatchers.setMain(dispatcher)

--- a/prompt.md
+++ b/prompt.md
@@ -10,7 +10,7 @@
 
 - 本番実装は Android（Kotlin + Compose + Room + DataStore）。
 - 旧 Python CLI プロトタイプは削除済み。
-- Pythonは辞書seed生成スクリプト用途に限定する。
+- 辞書seed生成は `android/tools/seed-generator` の Kotlin/JVM CLI を使う。
 
 ---
 
@@ -33,6 +33,7 @@
   - `sorted_key`
   - `word`
   - `length`
+  - `is_common`
 - 候補詳細キャッシュ: `candidate_detail_cache`
   - `word`
   - `kanji`
@@ -49,23 +50,20 @@
 
 - メイン画面: 入力、検索、候補一覧、設定導線
 - 候補詳細画面: 読み・漢字・意味、必要時オンデマンド取得
+- クイズ画面: 難易度選択、カードタップ式入力、スコア/ストリーク表示、正解/不正解表示
 - 設定: テーマ切替、文字数範囲、追加seed適用
 - 履歴: 最新10件を保存・再利用
 
 ---
 
-## 補助スクリプト仕様（Python）
+## 補助ツール仕様（Kotlin/JVM）
 
-### `scripts/export_android_seed.py`
+### `android/tools/seed-generator`
 
-- JMdict XML（`.xml` / `.gz`）→ `anagram_seed.tsv`
-- 正規化・ひらがな判定・重複除去・長さフィルタを実施
-
-### `scripts/export_android_room_db.py`
-
-- JMdict XML（`.xml` / `.gz`）→ Room互換SQLite
-- `anagram_entries` / `candidate_detail_cache` を生成
-- `PRAGMA user_version=3` を設定
+- JMdict XML/gzip（`.xml` / `.gz`）→ `anagram_seed.tsv` / `anagram_seed.db`
+- 正規化・ひらがな判定・重複除去・長さフィルタ・一般語フラグ付与を実施
+- `anagram_entries` / `candidate_detail_cache` を含む Room互換SQLite を生成
+- `PRAGMA user_version=5` を設定
 
 ---
 
@@ -85,10 +83,10 @@ cd android && ./gradlew :app:connectedDebugAndroidTest
 # Android UI Tests（schedule含む）は安定性のため --configuration-cache を付けない
 
 # seed TSV生成
-python scripts/export_android_seed.py --xml ~/.jamdict/data/JMdict_e.gz --output android/app/src/main/assets/anagram_seed.tsv --min-len 2 --max-len 8
+cd android && ./gradlew :tools:seed-generator:run --args="--jmdict ~/.jamdict/data/JMdict_e.gz --out-tsv app/src/main/assets/anagram_seed.tsv --mode tsv --min-len 2 --max-len 8"
 
 # Room DB生成
-python scripts/export_android_room_db.py --xml ~/.jamdict/data/JMdict_e.gz --output android/app/src/main/assets/anagram_seed.db --min-len 2 --max-len 8 --force
+cd android && ./gradlew :tools:seed-generator:run --args="--jmdict ~/.jamdict/data/JMdict_e.gz --out-db app/src/main/assets/anagram_seed.db --mode db --min-len 2 --max-len 8 --force"
 ```
 
 ---

--- a/tasks.md
+++ b/tasks.md
@@ -19,6 +19,7 @@
 | 10: Issue #81 事前リファクタ | ✅ 完了 | MainViewModel UseCase分割・画面コンポーネント切り出し |
 | 11: Issue #60 クイズモード | ✅ 完了 | QuizDifficulty/QuizQuestion/GenerateQuizUseCase/QuizScoreStore/QuizViewModel/QuizScreen |
 | 12: Issue #88 クイズ単語重みづけ | ✅ 完了 | JMdict re_pri → isCommon フラグ・DB version 4・一般語優先出題 |
+| 13: Issue #40 クイズカードタップ式入力UI | ✅ 完了 | CharCard / カード配置UI / 回答スロット / 出題回避ロジック / Unit Test |
 
 ---
 
@@ -56,20 +57,21 @@
 
 ---
 
-## 未着手フェーズ
+## 直近フェーズ
 
 ### フェーズ 13: Issue #40 クイズカードタップ式入力UI
 
-- [ ] `CharCard` データクラスを定義（`id: Int`, `char: Char`, `isPlaced: Boolean`）
-- [ ] `QuizUiState` を新フィールド構成に更新（`shuffledCards` / `answerSlots` / `selectedCardId` 追加、`inputAnswer` 削除）
-- [ ] `QuizViewModel` に `onCardTapped` / `onSlotTapped` を追加し `onInputAnswerChanged` を削除
-- [ ] `onSubmitAnswer` を `answerSlots` から文字列組み立て→判定する方式に変更
-- [ ] `GenerateQuizUseCase` が `shuffledCards: List<CharCard>` を返すよう更新
-- [ ] `QuizScreen.kt` の `AnsweringSection` をカード選択UI + 解答グリッドに刷新
-- [ ] 選択ハイライト（`animateColorAsState`）・グリッドハイライト（`animateDpAsState`）を実装
-- [ ] 配置時バウンスアニメーション（`spring`, DampingRatioMediumBouncy）+ 触覚フィードバックを実装
-- [ ] `QuizViewModelTest.kt` に新操作イベントのユニットテストを追加
-- [ ] 既存の正誤判定テスト・スコアテストが通過する
+- [x] `CharCard` データクラスを定義（`id: Int`, `char: Char`, `isPlaced: Boolean`）
+- [x] `QuizUiState` を新フィールド構成に更新（`shuffledCards` / `answerSlots` / `selectedCardId` 追加、`inputAnswer` 削除）
+- [x] `QuizViewModel` に `onCardTapped` / `onSlotTapped` を追加し `onInputAnswerChanged` を削除
+- [x] `onSubmitAnswer` を `answerSlots` から文字列組み立て→判定する方式に変更
+- [x] `GenerateQuizUseCase` が `shuffledCards: List<CharCard>` を返すよう更新
+- [x] `QuizScreen.kt` の `AnsweringSection` をカード選択UI + 解答グリッドに刷新
+- [x] 選択ハイライト（`animateColorAsState`）・グリッドハイライト（`animateDpAsState`）を実装
+- [x] 配置時バウンスアニメーション（`spring`, DampingRatioMediumBouncy）+ 触覚フィードバックを実装
+- [x] 正解の並びそのままの出題を回避し、回避不能時は別問題へ切り替えるロジックを追加
+- [x] `QuizViewModelTest.kt` に新操作イベントのユニットテストを追加
+- [x] Android SDK がある環境で `:app:testDebugUnitTest` を再実行し、Issue #40 / 出題回避テストの通過を確認する
 
 ### フェーズ 14: Issue #14 クイズモード拡張（タイマー・ヒント・ランキング・デコレーション）
 
@@ -113,11 +115,11 @@
 
 | フェーズ | 状態 | 備考 |
 |---------|------|------|
-| 0〜3, 8〜12 | ✅ 完了 | `tasks_archive_20260421.md` 参照 |
+| 0〜3, 8〜13 | ✅ 完了 | `tasks_archive_20260421.md` 参照 |
 | 4: UI実装 | 🟡 進行中 | お気に入り機能のみ未着手 |
 | 5: 辞書データ | 🟡 進行中 | オフライン検証のみ未着手 |
 | 6: 追加機能 | 🟡 進行中 | お気に入り機能のみ未着手 |
 | 7: CI/CD・リリース | 🟡 進行中 | ProGuard・ストア公開準備が未着手 |
-| 13: Issue #40 カードUI | ⬜ 未着手 | 次イテレーション最優先 |
+| 13: Issue #40 カードUI | ✅ 完了 | カードUI、出題回避ロジック、ユニットテスト追加、ローカル `:app:testDebugUnitTest` 通過まで完了 |
 | 14: Issue #14 クイズ拡張 | ⬜ 未着手 | #40 完了後に着手 |
 | 15: Issue #12 主役化 | ⬜ 未着手 | クイズ品質確立後に着手 |


### PR DESCRIPTION
## 概要
- Issue #40 として、クイズ回答をテキスト入力からカードタップ式 UI に変更しました。
- 出題時に正解候補そのものの並びで問題が出るケースを回避し、回避不能な場合は別の問題へ切り替えるようにしました。
- 関連するドキュメントを更新し、ローカルで Unit Test と `assembleDebug` を確認しました。

## 変更内容
- `CharCard` と `answerSlots` / `selectedCardId` を導入し、カード配置・取り消し・入れ替えに対応
- `QuizScreen` をカードUIへ刷新し、選択ハイライト、スロットハイライト、バウンスアニメーション、触覚フィードバックを追加
- `GenerateQuizUseCase` を更新し、正解候補や `sortedKey` と同一の並びを出題しないよう変更
- `QuizViewModelTest` と `GenerateQuizUseCaseTest` を追加・更新
- `tasks.md` / `CHANGELOG.md` / `AGENTS.md` / `README.md` / `prompt.md` を更新

## 背景
- 現状のクイズUIは文字列入力前提で、Issue #40 のカードタップ式体験になっていませんでした。
- あわせて、問題文が正解の並びそのものになるケースがあり、クイズとして成立しない状態がありました。

## 影響
- クイズ画面の回答操作がカードベースに変わります。
- 出題ロジックが一般語優先に加えて、正解並びの除外と別問題フォールバックを行うようになります。

## 確認内容
- `cd android && ./gradlew :app:testDebugUnitTest`
- `cd android && ./gradlew :app:assembleDebug`
