### PR TITLE
chore: lefthook を導入（pre-push で :app ユニットテスト）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Added
 
+- lefthook 導入（`lefthook.yml`）: pre-push で `:app:testDebugUnitTest` を実行。Kotlin リンタ（ktlint）は #62、`:tools:seed-generator:test` の pre-push 復帰は #63 で対応予定。
 - **Issue #40 クイズカードタップ式入力UI**
   - `domain/model/CharCard.kt` を追加し、カード単位の配置状態を表現可能に更新
   - `ui/viewmodel/QuizViewModelTest.kt` にカード配置/移動イベントのテストを追加

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 
 ## Androidアプリ開発
 
+### Git フック（lefthook）
+
+本リポジトリは [lefthook](https://github.com/evilmartians/lefthook) で pre-push に Android ユニットテストを設定している。**clone 後に一度だけ**フックを登録すること（登録しないとフックは動作しない）。
+
+```bash
+# lefthook 未導入なら先にインストール（例: go install / Homebrew / scoop 等）
+lefthook install
+```
+
 ### ビルド
 
 ```bash

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+# lefthook: anagram-analyzer (Kotlin/Android)
+# Kotlin リンタは現状未導入（後続 ISSUE で ktlint CLI 導入を検討）。
+# pre-push で Android ユニットテストを実行し、push 前の最終ゲートとする。
+# NOTE: CI は :tools:seed-generator:test も実行するが、当該テスト(SeedGeneratorIntegrationTest)が
+#       ローカル(Windows/cp932)で TSV 比較に失敗するため、push をブロックしないよう一旦 :app のみに限定。
+#       seed-generator テストの環境依存を解消後に再追加すること。
+pre-push:
+  commands:
+    unit-test:
+      root: "android/"
+      run: ./gradlew :app:testDebugUnitTest --no-daemon


### PR DESCRIPTION
## 概要
lefthook を導入し、push 前に Android ユニットテストを実行する。

## 変更
- `lefthook.yml` 追加
  - **pre-push**: `./gradlew :app:testDebugUnitTest`（`root: android/`）
- `CHANGELOG.md` 更新

## 検証
- `lefthook run pre-push --all-files` で lefthook 経由の `./gradlew` 起動を確認。`:app:testDebugUnitTest` は緑。

## 既知の制約 / 後続
- CI が回す `:tools:seed-generator:test` は、ローカル（Windows/cp932）で `SeedGeneratorIntegrationTest` の TSV 比較が `ComparisonFailure` で失敗するため、push をブロックしないよう pre-push から一旦除外（`lefthook.yml` に NOTE 記載）。環境依存の解消と復帰は #63。
- Kotlin リンタ（ktlint CLI）の pre-commit 導入は #62。

🤖 Generated with [Claude Code](https://claude.com/claude-code)