### PR TITLE
fix: SeedGeneratorIntegrationTest の環境依存失敗を解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Added
 
-- lefthook 導入（`lefthook.yml`）: pre-push で `:app:testDebugUnitTest` を実行。Kotlin リンタ（ktlint）は #62、`:tools:seed-generator:test` の pre-push 復帰は #63 で対応予定。
+- lefthook 導入（`lefthook.yml`）: pre-push で `:app:testDebugUnitTest` と `:tools:seed-generator:test` を実行。Kotlin リンタ（ktlint）は #62 で対応予定。
 - **Issue #40 クイズカードタップ式入力UI**
   - `domain/model/CharCard.kt` を追加し、カード単位の配置状態を表現可能に更新
   - `ui/viewmodel/QuizViewModelTest.kt` にカード配置/移動イベントのテストを追加
@@ -15,6 +15,8 @@
 
 ### Changed
 
+- `SeedGeneratorIntegrationTest` の TSV ゴールデン比較で改行コードを正規化し、Windows / cp932 環境の CRLF 差分で失敗しないよう変更
+- lefthook `pre-push` に `:tools:seed-generator:test` を復帰し、CI と同等の seed-generator テストを push 前に実行するよう変更
 - `QuizQuestion` を `shuffledCards` ベースへ更新し、`QuizUiState` を `shuffledCards` / `answerSlots` / `selectedCardId` 構成へ変更
 - `QuizViewModel` をカードタップ入力方式へ更新し、スロット配置・取り消し・入れ替えから回答判定できるよう変更
 - `QuizScreen` の回答UIをテキスト入力からカード選択グリッドへ刷新し、選択ハイライト・スロットハイライト・バウンスアニメーション・触覚フィードバックを追加

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ### Git フック（lefthook）
 
-本リポジトリは [lefthook](https://github.com/evilmartians/lefthook) で pre-push に Android ユニットテストを設定している。**clone 後に一度だけ**フックを登録すること（登録しないとフックは動作しない）。
+本リポジトリは [lefthook](https://github.com/evilmartians/lefthook) で pre-push に Android / seed-generator のユニットテストを設定している。**clone 後に一度だけ**フックを登録すること（登録しないとフックは動作しない）。
 
 ```bash
 # lefthook 未導入なら先にインストール（例: go install / Homebrew / scoop 等）

--- a/android/tools/seed-generator/src/test/kotlin/com/anagram/tools/seedgenerator/SeedGeneratorIntegrationTest.kt
+++ b/android/tools/seed-generator/src/test/kotlin/com/anagram/tools/seedgenerator/SeedGeneratorIntegrationTest.kt
@@ -16,7 +16,9 @@ class SeedGeneratorIntegrationTest {
     }
 
     private val expectedTsv by lazy {
-        javaClass.classLoader.getResource("expected_anagram_seed.tsv")!!.readText(Charsets.UTF_8)
+        javaClass.classLoader.getResource("expected_anagram_seed.tsv")!!
+            .readText(Charsets.UTF_8)
+            .normalizeLineEndings()
     }
 
     @Test
@@ -45,7 +47,7 @@ class SeedGeneratorIntegrationTest {
         val outTsv = tmp.newFile("out.tsv").toPath()
         val rows = JmdictParser.parse(fixtureXml, minLen = 2, maxLen = 8)
         TsvExporter.export(rows, outTsv)
-        val actual = outTsv.toFile().readText(Charsets.UTF_8)
+        val actual = outTsv.toFile().readText(Charsets.UTF_8).normalizeLineEndings()
         assertEquals(expectedTsv, actual)
     }
 
@@ -106,4 +108,6 @@ class SeedGeneratorIntegrationTest {
             }
         }
     }
+
+    private fun String.normalizeLineEndings(): String = replace("\r\n", "\n")
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,11 +1,8 @@
 # lefthook: anagram-analyzer (Kotlin/Android)
 # Kotlin リンタは現状未導入（後続 ISSUE で ktlint CLI 導入を検討）。
-# pre-push で Android ユニットテストを実行し、push 前の最終ゲートとする。
-# NOTE: CI は :tools:seed-generator:test も実行するが、当該テスト(SeedGeneratorIntegrationTest)が
-#       ローカル(Windows/cp932)で TSV 比較に失敗するため、push をブロックしないよう一旦 :app のみに限定。
-#       seed-generator テストの環境依存を解消後に再追加すること。
+# pre-push で Android / seed-generator のユニットテストを実行し、push 前の最終ゲートとする。
 pre-push:
   commands:
     unit-test:
       root: "android/"
-      run: ./gradlew :app:testDebugUnitTest --no-daemon
+      run: ./gradlew :app:testDebugUnitTest :tools:seed-generator:test --no-daemon

--- a/tasks.md
+++ b/tasks.md
@@ -20,6 +20,7 @@
 | 11: Issue #60 クイズモード | ✅ 完了 | QuizDifficulty/QuizQuestion/GenerateQuizUseCase/QuizScoreStore/QuizViewModel/QuizScreen |
 | 12: Issue #88 クイズ単語重みづけ | ✅ 完了 | JMdict re_pri → isCommon フラグ・DB version 4・一般語優先出題 |
 | 13: Issue #40 クイズカードタップ式入力UI | ✅ 完了 | CharCard / カード配置UI / 回答スロット / 出題回避ロジック / Unit Test |
+| 16: Issue #63 seed-generator テスト復帰 | ✅ 完了 | TSV比較の改行依存解消 / pre-push への seed-generator test 復帰 |
 
 ---
 
@@ -88,6 +89,12 @@
 - [ ] 解析モードをオプショナル（プレミアム機能）に移行
 - [ ] フリーミアム設計・課金導線の設計・実装
 
+### フェーズ 16: Issue #63 seed-generator テスト復帰
+
+- [x] `SeedGeneratorIntegrationTest` の TSV ゴールデン比較を改行コード非依存に修正
+- [x] ローカル Windows で `:tools:seed-generator:test` が通ることを確認
+- [x] lefthook `pre-push` に `:tools:seed-generator:test` を復帰し、NOTE コメントを削除
+
 ---
 
 ## 実装推奨順序
@@ -115,7 +122,7 @@
 
 | フェーズ | 状態 | 備考 |
 |---------|------|------|
-| 0〜3, 8〜13 | ✅ 完了 | `tasks_archive_20260421.md` 参照 |
+| 0〜3, 8〜13, 16 | ✅ 完了 | `tasks_archive_20260421.md` 参照 |
 | 4: UI実装 | 🟡 進行中 | お気に入り機能のみ未着手 |
 | 5: 辞書データ | 🟡 進行中 | オフライン検証のみ未着手 |
 | 6: 追加機能 | 🟡 進行中 | お気に入り機能のみ未着手 |
@@ -123,3 +130,4 @@
 | 13: Issue #40 カードUI | ✅ 完了 | カードUI、出題回避ロジック、ユニットテスト追加、ローカル `:app:testDebugUnitTest` 通過まで完了 |
 | 14: Issue #14 クイズ拡張 | ⬜ 未着手 | #40 完了後に着手 |
 | 15: Issue #12 主役化 | ⬜ 未着手 | クイズ品質確立後に着手 |
+| 16: Issue #63 seed-generator テスト復帰 | ✅ 完了 | Windows の TSV 比較失敗を修正し、pre-push に `:tools:seed-generator:test` を復帰 |


### PR DESCRIPTION
## 概要

- `SeedGeneratorIntegrationTest` の TSV ゴールデン比較で CRLF / LF 差分を正規化
- lefthook `pre-push` に `:tools:seed-generator:test` を復帰
- README / CHANGELOG / tasks.md を #63 の完了内容に合わせて更新

## 背景

Windows checkout では fixture TSV が CRLF になり、`TsvExporter` の LF 出力と文字列比較で差分が発生していました。出力仕様は変更せず、テスト比較側で改行コードのみ正規化します。

Closes #63

## 検証

- `lefthook validate`
- `./gradlew :app:testDebugUnitTest :tools:seed-generator:test --no-daemon`
- push 時の lefthook `pre-push` 実行