### PR TITLE
chore: lefthook の pre-commit に ktlint CLI を導入

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.{kt,kts}]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+ktlint_code_style = intellij_idea
+ktlint_function_naming_ignore_when_annotated_with = Composable,Test

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.kt text eol=lf
+*.kts text eol=lf
+android/tools/seed-generator/src/test/resources/*.tsv text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ htmlcov/
 *.sqlite
 *.sqlite3
 
+# Local tool cache
+.cache/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.lefthook/ktlint.ps1
+++ b/.lefthook/ktlint.ps1
@@ -1,0 +1,81 @@
+param(
+    [switch]$Format,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Files
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$version = "1.8.0"
+$expectedSha256 = "A3FD620207D5C40DA6CA789B95E7F823C54E854B7FADE7F613E91096A3706D75"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$cacheDir = Join-Path $repoRoot ".cache/ktlint"
+$ktlintJar = Join-Path $cacheDir "ktlint-$version.jar"
+$downloadUrl = "https://github.com/ktlint/ktlint/releases/download/$version/ktlint"
+
+function Assert-KtlintHash {
+    param([string]$Path)
+
+    $actualSha256 = Get-FileSha256 -Path $Path
+    if ($actualSha256 -ne $expectedSha256) {
+        throw "ktlint $version SHA-256 mismatch. expected=$expectedSha256 actual=$actualSha256"
+    }
+}
+
+function Get-FileSha256 {
+    param([string]$Path)
+
+    if (Get-Command Get-FileHash -ErrorAction SilentlyContinue) {
+        return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToUpperInvariant()
+    }
+
+    $certutilOutput = & certutil -hashfile $Path SHA256
+    if ($LASTEXITCODE -ne 0) {
+        throw "certutil failed to calculate SHA-256 for $Path"
+    }
+
+    $hashLine = $certutilOutput |
+        Where-Object { $_ -match "^[0-9A-Fa-f ]{64,}$" } |
+        Select-Object -First 1
+    if (-not $hashLine) {
+        throw "certutil SHA-256 output was not recognized for $Path"
+    }
+    return ($hashLine -replace "\s", "").ToUpperInvariant()
+}
+
+function Ensure-Ktlint {
+    if (Test-Path -LiteralPath $ktlintJar) {
+        Assert-KtlintHash -Path $ktlintJar
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+    $tempPath = "$ktlintJar.download"
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tempPath
+        Assert-KtlintHash -Path $tempPath
+        Move-Item -LiteralPath $tempPath -Destination $ktlintJar -Force
+    } catch {
+        if (Test-Path -LiteralPath $tempPath) {
+            Remove-Item -LiteralPath $tempPath -Force
+        }
+        throw
+    }
+}
+
+if ($Files.Count -eq 0) {
+    Write-Host "No Kotlin files for ktlint."
+    exit 0
+}
+
+Ensure-Ktlint
+
+$ktlintArgs = @("-jar", $ktlintJar, "--relative")
+if ($Format) {
+    $ktlintArgs += "--format"
+}
+$ktlintArgs += $Files
+
+& java @ktlintArgs
+exit $LASTEXITCODE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ JMdict XML/gzip から `anagram_seed.tsv` / Room互換SQLite を生成する独�
 | `HiraganaNormalizer.kt` | NFKC正規化・カタカナ→ひらがな・ひらがな判定・anagramKey（Python版互換） |
 | `JmdictParser.kt` | StAXベースXML/gzipパーサ。AnagramRowデータクラスを返す |
 | `TsvExporter.kt` | word順ソートでTSV出力（`sorted_key\tword\tlength\n`） |
-| `DbExporter.kt` | Room互換SQLite生成（`PRAGMA user_version=3`、`anagram_entries` + `candidate_detail_cache`、全インデックス付） |
+| `DbExporter.kt` | Room互換SQLite生成（`PRAGMA user_version=5`、`anagram_entries` + `candidate_detail_cache`、全インデックス付） |
 
 ## 開発コマンド
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ anagram-analyzer/
 │   │       └── src/
 │   │           ├── main/kotlin/com/anagram/tools/seedgenerator/
 │   │           │   ├── Main.kt
-│   │           │   ├── Normalizer.kt
+│   │           │   ├── HiraganaNormalizer.kt
 │   │           │   ├── JmdictParser.kt
 │   │           │   ├── TsvExporter.kt
 │   │           │   └── DbExporter.kt
@@ -146,12 +146,26 @@ JMdict XML/gzip から `anagram_seed.tsv` / Room互換SQLite を生成する独�
 | ファイル | 説明 |
 |---------|------|
 | `Main.kt` | CLIエントリポイント（`--jmdict/--out-tsv/--out-db/--mode/--min-len/--max-len/--limit/--force`） |
-| `Normalizer.kt` | NFKC正規化・カタカナ→ひらがな・ひらがな判定・anagramKey（Python版互換） |
+| `HiraganaNormalizer.kt` | NFKC正規化・カタカナ→ひらがな・ひらがな判定・anagramKey（Python版互換） |
 | `JmdictParser.kt` | StAXベースXML/gzipパーサ。AnagramRowデータクラスを返す |
 | `TsvExporter.kt` | word順ソートでTSV出力（`sorted_key\tword\tlength\n`） |
 | `DbExporter.kt` | Room互換SQLite生成（`PRAGMA user_version=3`、`anagram_entries` + `candidate_detail_cache`、全インデックス付） |
 
 ## 開発コマンド
+
+### Git hooks / ktlint
+
+```bash
+# clone後に一度だけ実行
+lefthook install
+
+# hook設定の検証
+lefthook validate
+```
+
+- `pre-commit`: `.lefthook/ktlint.ps1` 経由で ktlint CLI 1.8.0 を実行し、staged な `*.kt` を整形する
+- `pre-push`: `:app:testDebugUnitTest` と `:tools:seed-generator:test` を実行する
+- ktlint CLI は `.cache/ktlint/` に取得し、SHA-256 を検証してから `java -jar` で実行する
 
 ### Android
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 ### Added
 
 - lefthook 導入（`lefthook.yml`）: pre-push で `:app:testDebugUnitTest` と `:tools:seed-generator:test` を実行。Kotlin リンタ（ktlint）は #62 で対応予定。
+- **Issue #62 ktlint CLI pre-commit 導入**
+  - ktlint CLI 1.8.0 をバージョン固定し、lefthook `pre-commit` で staged な `*.kt` を自動整形する設定を追加
+  - `.lefthook/ktlint.ps1` を追加し、ktlint CLI を `.cache/ktlint/` へ取得して SHA-256 検証後に `java -jar` で実行するようにした
+  - `.editorconfig` / `.gitattributes` を追加し、Kotlin の ktlint 設定と LF 改行を明示
 - **Issue #40 クイズカードタップ式入力UI**
   - `domain/model/CharCard.kt` を追加し、カード単位の配置状態を表現可能に更新
   - `ui/viewmodel/QuizViewModelTest.kt` にカード配置/移動イベントのテストを追加
@@ -17,6 +21,7 @@
 
 - `SeedGeneratorIntegrationTest` の TSV ゴールデン比較で改行コードを正規化し、Windows / cp932 環境の CRLF 差分で失敗しないよう変更
 - lefthook `pre-push` に `:tools:seed-generator:test` を復帰し、CI と同等の seed-generator テストを push 前に実行するよう変更
+- ktlint 初回整形を適用し、seed-generator の `Normalizer.kt` を `HiraganaNormalizer.kt` にリネーム
 - `QuizQuestion` を `shuffledCards` ベースへ更新し、`QuizUiState` を `shuffledCards` / `answerSlots` / `selectedCardId` 構成へ変更
 - `QuizViewModel` をカードタップ入力方式へ更新し、スロット配置・取り消し・入れ替えから回答判定できるよう変更
 - `QuizScreen` の回答UIをテキスト入力からカード選択グリッドへ刷新し、選択ハイライト・スロットハイライト・バウンスアニメーション・触覚フィードバックを追加

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ lefthook install
 - `pre-commit`: staged な `*.kt` を ktlint CLI 1.8.0 で自動整形し、修正分を再 stage する
 - `pre-push`: `:app:testDebugUnitTest` と `:tools:seed-generator:test` を実行する
 - ktlint CLI は初回実行時に `.cache/ktlint/` へ取得され、SHA-256 検証後に `java -jar` で実行される
+- ktlint の pre-commit には `powershell` コマンドと Java が必要。Windows 標準環境を前提にしているため、macOS / Linux では PowerShell を別途導入する
 
 ### ビルド
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@
 
 ### Git フック（lefthook）
 
-本リポジトリは [lefthook](https://github.com/evilmartians/lefthook) で pre-push に Android / seed-generator のユニットテストを設定している。**clone 後に一度だけ**フックを登録すること（登録しないとフックは動作しない）。
+本リポジトリは [lefthook](https://github.com/evilmartians/lefthook) で Git hook を管理している。**clone 後に一度だけ**フックを登録すること（登録しないとフックは動作しない）。
 
 ```bash
 # lefthook 未導入なら先にインストール（例: go install / Homebrew / scoop 等）
 lefthook install
 ```
+
+- `pre-commit`: staged な `*.kt` を ktlint CLI 1.8.0 で自動整形し、修正分を再 stage する
+- `pre-push`: `:app:testDebugUnitTest` と `:tools:seed-generator:test` を実行する
+- ktlint CLI は初回実行時に `.cache/ktlint/` へ取得され、SHA-256 検証後に `java -jar` で実行される
 
 ### ビルド
 

--- a/android/app/src/androidTest/java/com/anagram/analyzer/data/seed/AssetSeedEntryLoaderInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/anagram/analyzer/data/seed/AssetSeedEntryLoaderInstrumentedTest.kt
@@ -6,12 +6,12 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.anagram.analyzer.data.db.ANAGRAM_DATABASE_VERSION
 import com.anagram.analyzer.data.db.AnagramEntry
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlinx.coroutines.runBlocking
 import java.io.File
 
 @RunWith(AndroidJUnit4::class)

--- a/android/app/src/androidTest/java/com/anagram/analyzer/ui/screen/MainScreenTest.kt
+++ b/android/app/src/androidTest/java/com/anagram/analyzer/ui/screen/MainScreenTest.kt
@@ -3,11 +3,11 @@ package com.anagram.analyzer.ui.screen
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
@@ -228,6 +228,5 @@ class MainScreenTest {
             composeRule.onAllNodesWithText(expectedAfterToggle).fetchSemanticsNodes().isNotEmpty()
         }
         composeRule.onNodeWithText(expectedAfterToggle).assertIsDisplayed()
-
     }
 }

--- a/android/app/src/main/java/com/anagram/analyzer/MainActivity.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/MainActivity.kt
@@ -3,25 +3,25 @@ package com.anagram.analyzer
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import com.anagram.analyzer.data.datastore.ThemePreferenceStore
 import com.anagram.analyzer.ui.screen.MainScreen
 import com.anagram.analyzer.ui.screen.QuizScreen
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {

--- a/android/app/src/main/java/com/anagram/analyzer/data/datastore/InputHistoryStore.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/datastore/InputHistoryStore.kt
@@ -5,12 +5,12 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 
 interface InputHistoryStore {
     val inputHistory: Flow<List<String>>

--- a/android/app/src/main/java/com/anagram/analyzer/data/datastore/QuizScoreStore.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/datastore/QuizScoreStore.kt
@@ -5,10 +5,10 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import java.io.IOException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import java.io.IOException
 
 private val Context.quizScoreDataStore by preferencesDataStore(name = "quiz_score")
 

--- a/android/app/src/main/java/com/anagram/analyzer/data/datastore/SearchSettingsStore.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/datastore/SearchSettingsStore.kt
@@ -5,12 +5,12 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 
 data class SearchSettings(
     val minLength: Int = DEFAULT_MIN_LENGTH,

--- a/android/app/src/main/java/com/anagram/analyzer/data/datastore/ThemePreferenceStore.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/datastore/ThemePreferenceStore.kt
@@ -5,12 +5,12 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 
 @Singleton
 class ThemePreferenceStore @Inject constructor(

--- a/android/app/src/main/java/com/anagram/analyzer/data/db/AnagramDatabase.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/db/AnagramDatabase.kt
@@ -80,16 +80,14 @@ abstract class AnagramDatabase : RoomDatabase() {
                 }
             }
 
-        fun getInstance(context: Context): AnagramDatabase {
-            return instance ?: synchronized(this) {
-                instance ?: Room.databaseBuilder(
-                    context.applicationContext,
-                    AnagramDatabase::class.java,
-                    "anagram.db",
-                ).addMigrations(migration1To2, migration2To3, migration3To4, migration4To5)
-                    .build()
-                    .also { instance = it }
-            }
+        fun getInstance(context: Context): AnagramDatabase = instance ?: synchronized(this) {
+            instance ?: Room.databaseBuilder(
+                context.applicationContext,
+                AnagramDatabase::class.java,
+                "anagram.db",
+            ).addMigrations(migration1To2, migration2To3, migration3To4, migration4To5)
+                .build()
+                .also { instance = it }
         }
     }
 }

--- a/android/app/src/main/java/com/anagram/analyzer/data/seed/AssetAdditionalSeedEntryLoader.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/seed/AssetAdditionalSeedEntryLoader.kt
@@ -13,17 +13,15 @@ interface AdditionalSeedEntryLoader {
 class AssetAdditionalSeedEntryLoader @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : AdditionalSeedEntryLoader {
-    override suspend fun loadEntries(): List<AnagramEntry> {
-        return try {
-            context.assets.open(ASSET_FILE_NAME).bufferedReader().use { reader ->
-                parseSeedEntries(
-                    lines = reader.lineSequence(),
-                    fileName = ASSET_FILE_NAME,
-                )
-            }
-        } catch (error: IOException) {
-            throw IllegalStateException("追加辞書データの読み込みに失敗しました", error)
+    override suspend fun loadEntries(): List<AnagramEntry> = try {
+        context.assets.open(ASSET_FILE_NAME).bufferedReader().use { reader ->
+            parseSeedEntries(
+                lines = reader.lineSequence(),
+                fileName = ASSET_FILE_NAME,
+            )
         }
+    } catch (error: IOException) {
+        throw IllegalStateException("追加辞書データの読み込みに失敗しました", error)
     }
 
     private companion object {

--- a/android/app/src/main/java/com/anagram/analyzer/data/seed/AssetCandidateDetailLoader.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/seed/AssetCandidateDetailLoader.kt
@@ -78,24 +78,18 @@ class AssetCandidateDetailLoader @Inject constructor(
 internal fun mergeCandidateDetails(
     seedDetails: Map<String, CandidateDetail>,
     cachedDetails: Map<String, CandidateDetail>,
-): Map<String, CandidateDetail> {
-    return seedDetails + cachedDetails.filterKeys { key -> key !in seedDetails }
-}
+): Map<String, CandidateDetail> = seedDetails + cachedDetails.filterKeys { key -> key !in seedDetails }
 
 internal fun resolveLocalCandidateDetail(
     word: String,
     seedDetails: Map<String, CandidateDetail>,
     cachedDetail: CandidateDetail?,
-): CandidateDetail? {
-    return seedDetails[word] ?: cachedDetail
-}
+): CandidateDetail? = seedDetails[word] ?: cachedDetail
 
-private fun CandidateDetailCacheEntry.toCandidateDetail(): CandidateDetail {
-    return CandidateDetail(
-        kanji = kanji,
-        meaning = meaning,
-    )
-}
+private fun CandidateDetailCacheEntry.toCandidateDetail(): CandidateDetail = CandidateDetail(
+    kanji = kanji,
+    meaning = meaning,
+)
 
 internal fun parseCandidateDetails(lines: Sequence<String>): Map<String, CandidateDetail> {
     val details = mutableMapOf<String, CandidateDetail>()

--- a/android/app/src/main/java/com/anagram/analyzer/data/seed/AssetSeedEntryLoader.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/seed/AssetSeedEntryLoader.kt
@@ -41,9 +41,7 @@ class AssetSeedEntryLoader @Inject constructor(
 internal fun resolveSeedEntries(
     dbEntries: List<AnagramEntry>?,
     tsvEntries: List<AnagramEntry>,
-): List<AnagramEntry> {
-    return dbEntries?.takeIf { it.isNotEmpty() } ?: tsvEntries
-}
+): List<AnagramEntry> = dbEntries?.takeIf { it.isNotEmpty() } ?: tsvEntries
 
 internal fun loadSeedEntriesFromDatabaseAsset(context: Context): List<AnagramEntry>? {
     var tempFile: File? = null
@@ -105,9 +103,7 @@ internal fun loadSeedEntriesFromDatabaseFile(path: String): List<AnagramEntry>? 
     }
 }
 
-internal fun parseSeedEntries(lines: Sequence<String>): List<AnagramEntry> {
-    return parseSeedEntries(lines, ASSET_FILE_NAME)
-}
+internal fun parseSeedEntries(lines: Sequence<String>): List<AnagramEntry> = parseSeedEntries(lines, ASSET_FILE_NAME)
 
 internal fun parseSeedEntries(
     lines: Sequence<String>,

--- a/android/app/src/main/java/com/anagram/analyzer/data/seed/JishoCandidateDetailRemoteDataSource.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/data/seed/JishoCandidateDetailRemoteDataSource.kt
@@ -1,16 +1,16 @@
 package com.anagram.analyzer.data.seed
 
-import java.io.IOException
-import java.net.HttpURLConnection
-import java.net.URL
-import java.net.URLEncoder
-import javax.inject.Inject
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import javax.inject.Inject
 
 interface CandidateDetailRemoteDataSource {
     @Throws(IOException::class)

--- a/android/app/src/main/java/com/anagram/analyzer/domain/usecase/PreloadSeedUseCase.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/domain/usecase/PreloadSeedUseCase.kt
@@ -69,8 +69,7 @@ class PreloadSeedUseCase @Inject constructor(
         val elapsedMillis: Long,
     )
 
-    private fun PreloadMetrics.toLogLine(): String =
-        "preload source=$source total=$totalEntries inserted=$insertedEntries elapsedMs=$elapsedMillis"
+    private fun PreloadMetrics.toLogLine(): String = "preload source=$source total=$totalEntries inserted=$insertedEntries elapsedMs=$elapsedMillis"
 
     private companion object {
         private val DEMO_ENTRIES = listOf(

--- a/android/app/src/main/java/com/anagram/analyzer/ui/screen/MainScreen.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/screen/MainScreen.kt
@@ -12,8 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -26,12 +26,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -344,4 +344,3 @@ fun MainScreenContent(
         )
     }
 }
-

--- a/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
@@ -128,12 +128,14 @@ fun QuizScreenContent(
                 onDifficultySelected = onDifficultySelected,
                 onStartQuiz = onStartQuiz,
             )
+
             QuizPhase.LOADING -> Box(
                 modifier = Modifier.fillMaxWidth(),
                 contentAlignment = Alignment.Center,
             ) {
                 CircularProgressIndicator(modifier = Modifier.size(48.dp))
             }
+
             QuizPhase.ANSWERING -> AnsweringSection(
                 shuffledCards = state.shuffledCards,
                 answerSlots = state.answerSlots,
@@ -143,11 +145,13 @@ fun QuizScreenContent(
                 onSlotTapped = onSlotTapped,
                 onSubmitAnswer = onSubmitAnswer,
             )
+
             QuizPhase.CORRECT -> ResultSection(
                 isCorrect = true,
                 correctWords = state.question?.correctWords ?: emptyList(),
                 onNextQuestion = onNextQuestion,
             )
+
             QuizPhase.INCORRECT -> ResultSection(
                 isCorrect = false,
                 correctWords = state.question?.correctWords ?: emptyList(),
@@ -605,8 +609,7 @@ private fun ResultSection(
     }
 }
 
-private fun calculateCardsPerRow(maxWidth: Dp): Int =
-    (maxWidth / QUIZ_CARD_FOOTPRINT).toInt().coerceAtLeast(1)
+private fun calculateCardsPerRow(maxWidth: Dp): Int = (maxWidth / QUIZ_CARD_FOOTPRINT).toInt().coerceAtLeast(1)
 
 private val QUIZ_CARD_SIZE = 56.dp
 private val QUIZ_CARD_HORIZONTAL_PADDING = 6.dp

--- a/android/app/src/main/java/com/anagram/analyzer/ui/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/viewmodel/MainViewModel.kt
@@ -330,12 +330,10 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    private fun appendInputHistory(history: List<String>, value: String): List<String> {
-        return buildList {
-            add(value)
-            addAll(history.filterNot { it == value })
-        }.take(MAX_INPUT_HISTORY)
-    }
+    private fun appendInputHistory(history: List<String>, value: String): List<String> = buildList {
+        add(value)
+        addAll(history.filterNot { it == value })
+    }.take(MAX_INPUT_HISTORY)
 
     private companion object {
         private const val MAX_INPUT_HISTORY = 10

--- a/android/app/src/main/java/com/anagram/analyzer/ui/viewmodel/QuizViewModel.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/viewmodel/QuizViewModel.kt
@@ -64,12 +64,15 @@ class QuizViewModel @Inject constructor(
                         errorMessage = null,
                     )
                 }
+
                 state.selectedCardId == cardId -> {
                     state.copy(selectedCardId = null, errorMessage = null)
                 }
+
                 state.selectedCardId != null -> {
                     state.copy(selectedCardId = cardId, errorMessage = null)
                 }
+
                 else -> {
                     val firstEmptySlot = state.answerSlots.indexOfFirst { it == null }
                     if (firstEmptySlot == -1) {
@@ -116,6 +119,7 @@ class QuizViewModel @Inject constructor(
                         )
                     }
                 }
+
                 cardIdInSlot != null -> {
                     val nextSlots = state.answerSlots.toMutableList()
                     nextSlots[slotIndex] = null
@@ -126,6 +130,7 @@ class QuizViewModel @Inject constructor(
                         errorMessage = null,
                     )
                 }
+
                 else -> state
             }
         }
@@ -279,14 +284,13 @@ class QuizViewModel @Inject constructor(
         }
     }
 
-    private fun clearCardFromSlots(answerSlots: List<Int?>, cardId: Int): List<Int?> =
-        answerSlots.map { slotCardId ->
-            if (slotCardId == cardId) {
-                null
-            } else {
-                slotCardId
-            }
+    private fun clearCardFromSlots(answerSlots: List<Int?>, cardId: Int): List<Int?> = answerSlots.map { slotCardId ->
+        if (slotCardId == cardId) {
+            null
+        } else {
+            slotCardId
         }
+    }
 
     private companion object {
         private const val POINTS_PER_CORRECT = 10

--- a/android/app/src/test/java/com/anagram/analyzer/domain/usecase/GenerateQuizUseCaseTest.kt
+++ b/android/app/src/test/java/com/anagram/analyzer/domain/usecase/GenerateQuizUseCaseTest.kt
@@ -82,19 +82,15 @@ class GenerateQuizUseCaseTest {
     ) : AnagramDao {
         override suspend fun insertAll(entries: List<AnagramEntry>) = Unit
 
-        override suspend fun lookupWords(sortedKey: String): List<String> =
-            wordsBySortedKey[sortedKey].orEmpty()
+        override suspend fun lookupWords(sortedKey: String): List<String> = wordsBySortedKey[sortedKey].orEmpty()
 
         override suspend fun count(): Long = entries.size.toLong()
 
-        override suspend fun countByLength(minLen: Int, maxLen: Int): Int =
-            filterEntries(minLen, maxLen, commonOnly = false).size
+        override suspend fun countByLength(minLen: Int, maxLen: Int): Int = filterEntries(minLen, maxLen, commonOnly = false).size
 
-        override suspend fun getEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? =
-            filterEntries(minLen, maxLen, commonOnly = false).getOrNull(offset)
+        override suspend fun getEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? = filterEntries(minLen, maxLen, commonOnly = false).getOrNull(offset)
 
-        override suspend fun countCommonByLength(minLen: Int, maxLen: Int): Int =
-            filterEntries(minLen, maxLen, commonOnly = true).size
+        override suspend fun countCommonByLength(minLen: Int, maxLen: Int): Int = filterEntries(minLen, maxLen, commonOnly = true).size
 
         override suspend fun getCommonEntryAtOffset(
             minLen: Int,

--- a/android/app/src/test/java/com/anagram/analyzer/ui/viewmodel/MainViewModelTest.kt
+++ b/android/app/src/test/java/com/anagram/analyzer/ui/viewmodel/MainViewModelTest.kt
@@ -10,26 +10,26 @@ import com.anagram.analyzer.data.seed.AdditionalSeedEntryLoader
 import com.anagram.analyzer.data.seed.CandidateDetail
 import com.anagram.analyzer.data.seed.CandidateDetailLoader
 import com.anagram.analyzer.data.seed.SeedEntryLoader
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import com.anagram.analyzer.domain.model.PreloadLogger
 import com.anagram.analyzer.domain.usecase.ApplyAdditionalDictionaryUseCase
 import com.anagram.analyzer.domain.usecase.LoadCandidateDetailUseCase
 import com.anagram.analyzer.domain.usecase.PreloadSeedUseCase
 import com.anagram.analyzer.domain.usecase.SearchAnagramUseCase
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -853,17 +853,13 @@ class MainViewModelTest {
             return entries.size.toLong()
         }
 
-        override suspend fun countByLength(minLen: Int, maxLen: Int): Int =
-            entries.count { it.length in minLen..maxLen }
+        override suspend fun countByLength(minLen: Int, maxLen: Int): Int = entries.count { it.length in minLen..maxLen }
 
-        override suspend fun getEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? =
-            entries.filter { it.length in minLen..maxLen }.getOrNull(offset)
+        override suspend fun getEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? = entries.filter { it.length in minLen..maxLen }.getOrNull(offset)
 
-        override suspend fun countCommonByLength(minLen: Int, maxLen: Int): Int =
-            entries.count { it.length in minLen..maxLen && it.isCommon }
+        override suspend fun countCommonByLength(minLen: Int, maxLen: Int): Int = entries.count { it.length in minLen..maxLen && it.isCommon }
 
-        override suspend fun getCommonEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? =
-            entries.filter { it.length in minLen..maxLen && it.isCommon }.getOrNull(offset)
+        override suspend fun getCommonEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? = entries.filter { it.length in minLen..maxLen && it.isCommon }.getOrNull(offset)
     }
 
     private class FakeSeedEntryLoader(
@@ -883,9 +879,7 @@ class MainViewModelTest {
         private val fetchedDetails: Map<String, CandidateDetail> = emptyMap(),
         private val fetchFailure: IllegalStateException? = null,
     ) : CandidateDetailLoader {
-        override suspend fun loadDetails(): Map<String, CandidateDetail> {
-            return details
-        }
+        override suspend fun loadDetails(): Map<String, CandidateDetail> = details
 
         override suspend fun fetchDetail(word: String): CandidateDetail? {
             if (fetchFailure != null) {

--- a/android/app/src/test/java/com/anagram/analyzer/ui/viewmodel/QuizViewModelTest.kt
+++ b/android/app/src/test/java/com/anagram/analyzer/ui/viewmodel/QuizViewModelTest.kt
@@ -299,14 +299,11 @@ class QuizViewModelTest {
         override suspend fun lookupWords(sortedKey: String): List<String> = words
         override suspend fun count(): Long = if (randomEntry != null) 1L else 0L
 
-        override suspend fun countByLength(minLen: Int, maxLen: Int): Int =
-            if (randomEntry != null && randomEntry.length in minLen..maxLen) 1 else 0
+        override suspend fun countByLength(minLen: Int, maxLen: Int): Int = if (randomEntry != null && randomEntry.length in minLen..maxLen) 1 else 0
 
-        override suspend fun getEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? =
-            randomEntry?.takeIf { it.length in minLen..maxLen && offset == 0 }
+        override suspend fun getEntryAtOffset(minLen: Int, maxLen: Int, offset: Int): AnagramEntry? = randomEntry?.takeIf { it.length in minLen..maxLen && offset == 0 }
 
-        override suspend fun countCommonByLength(minLen: Int, maxLen: Int): Int =
-            if (randomEntry != null && randomEntry.length in minLen..maxLen && randomEntry.isCommon) 1 else 0
+        override suspend fun countCommonByLength(minLen: Int, maxLen: Int): Int = if (randomEntry != null && randomEntry.length in minLen..maxLen && randomEntry.isCommon) 1 else 0
 
         override suspend fun getCommonEntryAtOffset(
             minLen: Int,

--- a/android/tools/seed-generator/src/main/kotlin/com/anagram/tools/seedgenerator/HiraganaNormalizer.kt
+++ b/android/tools/seed-generator/src/main/kotlin/com/anagram/tools/seedgenerator/HiraganaNormalizer.kt
@@ -11,11 +11,10 @@ object HiraganaNormalizer {
         return katakanaToHiragana(noWs)
     }
 
-    fun katakanaToHiragana(input: String): String =
-        input.map { c ->
-            val cp = c.code
-            if (cp in 0x30A1..0x30F6) (cp - 0x60).toChar() else c
-        }.joinToString("")
+    fun katakanaToHiragana(input: String): String = input.map { c ->
+        val cp = c.code
+        if (cp in 0x30A1..0x30F6) (cp - 0x60).toChar() else c
+    }.joinToString("")
 
     fun isHiragana(c: Char): Boolean {
         val cp = c.code

--- a/android/tools/seed-generator/src/main/kotlin/com/anagram/tools/seedgenerator/JmdictParser.kt
+++ b/android/tools/seed-generator/src/main/kotlin/com/anagram/tools/seedgenerator/JmdictParser.kt
@@ -32,18 +32,37 @@ object JmdictParser {
             while (reader.hasNext()) {
                 when (reader.next()) {
                     XMLStreamConstants.START_ELEMENT -> when (reader.localName) {
-                        "r_ele" -> { inREle = true; rebBuf.clear(); rePris.clear() }
-                        "reb"   -> if (inREle) { inReb = true; rebBuf.clear() }
-                        "re_pri" -> if (inREle) { inRePri = true; rePriBuf.clear() }
+                        "r_ele" -> {
+                            inREle = true
+                            rebBuf.clear()
+                            rePris.clear()
+                        }
+
+                        "reb" -> if (inREle) {
+                            inReb = true
+                            rebBuf.clear()
+                        }
+
+                        "re_pri" -> if (inREle) {
+                            inRePri = true
+                            rePriBuf.clear()
+                        }
                     }
+
                     XMLStreamConstants.CHARACTERS, XMLStreamConstants.CDATA -> {
                         if (inReb) rebBuf.append(reader.text)
                         if (inRePri) rePriBuf.append(reader.text)
                     }
+
                     XMLStreamConstants.END_ELEMENT -> when (reader.localName) {
-                        "reb"    -> inReb = false
-                        "re_pri" -> if (inREle) { rePris.add(rePriBuf.toString().trim()); inRePri = false }
-                        "r_ele"  -> {
+                        "reb" -> inReb = false
+
+                        "re_pri" -> if (inREle) {
+                            rePris.add(rePriBuf.toString().trim())
+                            inRePri = false
+                        }
+
+                        "r_ele" -> {
                             inREle = false
                             val word = HiraganaNormalizer.normalize(rebBuf.toString().trim())
                             val isCommon = rePris.any { COMMON_PRI_REGEX.matches(it) }

--- a/android/tools/seed-generator/src/main/kotlin/com/anagram/tools/seedgenerator/Main.kt
+++ b/android/tools/seed-generator/src/main/kotlin/com/anagram/tools/seedgenerator/Main.kt
@@ -24,11 +24,13 @@ fun main(args: Array<String>) {
             TsvExporter.export(rows, outTsv)
             println("TSV出力完了: $outTsv")
         }
+
         "db" -> {
             val outDb = Paths.get(parsed["--out-db"] ?: "anagram_seed.db")
             DbExporter.export(rows, outDb, force)
             println("DB出力完了: $outDb")
         }
+
         "both" -> {
             val outTsv = Paths.get(parsed["--out-tsv"] ?: "anagram_seed.tsv")
             val outDb = Paths.get(parsed["--out-db"] ?: "anagram_seed.db")
@@ -37,6 +39,7 @@ fun main(args: Array<String>) {
             DbExporter.export(rows, outDb, force)
             println("DB出力完了: $outDb")
         }
+
         else -> error("--mode は tsv|db|both を指定してください")
     }
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,12 @@
 # lefthook: anagram-analyzer (Kotlin/Android)
-# Kotlin リンタは現状未導入（後続 ISSUE で ktlint CLI 導入を検討）。
+# ktlint CLI は .lefthook/ktlint.ps1 でバージョン固定して実行する。
+pre-commit:
+  commands:
+    ktlint:
+      glob: "*.kt"
+      run: powershell -NoProfile -ExecutionPolicy Bypass -File .lefthook/ktlint.ps1 -Format {staged_files}
+      stage_fixed: true
+
 # pre-push で Android / seed-generator のユニットテストを実行し、push 前の最終ゲートとする。
 pre-push:
   commands:

--- a/tasks.md
+++ b/tasks.md
@@ -21,6 +21,7 @@
 | 12: Issue #88 クイズ単語重みづけ | ✅ 完了 | JMdict re_pri → isCommon フラグ・DB version 4・一般語優先出題 |
 | 13: Issue #40 クイズカードタップ式入力UI | ✅ 完了 | CharCard / カード配置UI / 回答スロット / 出題回避ロジック / Unit Test |
 | 16: Issue #63 seed-generator テスト復帰 | ✅ 完了 | TSV比較の改行依存解消 / pre-push への seed-generator test 復帰 |
+| 17: Issue #62 ktlint CLI pre-commit 導入 | ✅ 完了 | ktlint CLI 1.8.0 固定 / pre-commit 自動整形 / 初回整形 |
 
 ---
 
@@ -95,6 +96,13 @@
 - [x] ローカル Windows で `:tools:seed-generator:test` が通ることを確認
 - [x] lefthook `pre-push` に `:tools:seed-generator:test` を復帰し、NOTE コメントを削除
 
+### フェーズ 17: Issue #62 ktlint CLI pre-commit 導入
+
+- [x] ktlint CLI 1.8.0 を `.lefthook/ktlint.ps1` 経由でバージョン固定導入
+- [x] lefthook `pre-commit` で staged な `*.kt` を ktlint format し、修正分を再 stage する設定を追加
+- [x] `.editorconfig` / `.gitattributes` を追加し、Compose / JUnit テスト命名と LF 改行を明示
+- [x] 既存 Kotlin コードへ ktlint 初回整形を適用
+
 ---
 
 ## 実装推奨順序
@@ -122,7 +130,7 @@
 
 | フェーズ | 状態 | 備考 |
 |---------|------|------|
-| 0〜3, 8〜13, 16 | ✅ 完了 | `tasks_archive_20260421.md` 参照 |
+| 0〜3, 8〜13, 16〜17 | ✅ 完了 | `tasks_archive_20260421.md` 参照 |
 | 4: UI実装 | 🟡 進行中 | お気に入り機能のみ未着手 |
 | 5: 辞書データ | 🟡 進行中 | オフライン検証のみ未着手 |
 | 6: 追加機能 | 🟡 進行中 | お気に入り機能のみ未着手 |
@@ -131,3 +139,4 @@
 | 14: Issue #14 クイズ拡張 | ⬜ 未着手 | #40 完了後に着手 |
 | 15: Issue #12 主役化 | ⬜ 未着手 | クイズ品質確立後に着手 |
 | 16: Issue #63 seed-generator テスト復帰 | ✅ 完了 | Windows の TSV 比較失敗を修正し、pre-push に `:tools:seed-generator:test` を復帰 |
+| 17: Issue #62 ktlint CLI pre-commit | ✅ 完了 | ktlint CLI 1.8.0 pre-commit、初回整形まで完了 |


### PR DESCRIPTION
## 概要

- ktlint CLI 1.8.0 をバージョン固定で導入
- lefthook `pre-commit` で staged な `*.kt` を自動整形し、修正分を再 stage
- `.editorconfig` / `.gitattributes` で ktlint 設定と Kotlin / TSV の LF 改行を明示
- 既存 Kotlin コードへ ktlint 初回整形を適用

## 方針

Gradle plugin は導入せず、`build.gradle.kts` は変更していません。Kotlin 2.3.21 / AGP 9.2.1 への影響を避けるため、`.lefthook/ktlint.ps1` から pinned CLI を取得し、SHA-256 検証後に `java -jar` で実行します。

初回整形差分は `style: ktlint初回整形を適用` として別コミットに分けています。

Closes #62

## 検証

- `lefthook validate`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .lefthook/ktlint.ps1 -Format <all kt files>`
- `./gradlew :app:testDebugUnitTest :tools:seed-generator:test --no-daemon`
- commit 時の lefthook `pre-commit`
- push 時の lefthook `pre-push`