### PR TITLE
feat: クイズモードをメインコンテンツ化（#12）

### DIFF
--- a/android/app/src/androidTest/java/com/anagram/analyzer/ui/screen/MainScreenTest.kt
+++ b/android/app/src/androidTest/java/com/anagram/analyzer/ui/screen/MainScreenTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.anagram.analyzer.MainActivity
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,6 +23,11 @@ import org.junit.runner.RunWith
 class MainScreenTest {
     @get:Rule
     val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun navigateToAnalysisMode() {
+        composeRule.onNodeWithTag("quiz_to_analysis_button").performClick()
+    }
 
     @Test
     fun ひらがな入力で候補を表示できる() {

--- a/android/app/src/main/java/com/anagram/analyzer/MainActivity.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/MainActivity.kt
@@ -36,7 +36,7 @@ class MainActivity : ComponentActivity() {
             }
             val isDarkTheme = isDarkThemeState ?: return@setContent
             val scope = rememberCoroutineScope()
-            var showQuiz by rememberSaveable { mutableStateOf(false) }
+            var showQuiz by rememberSaveable { mutableStateOf(true) }
             MaterialTheme(
                 colorScheme = if (isDarkTheme) anagramDarkColorScheme() else anagramLightColorScheme(),
             ) {

--- a/android/app/src/main/java/com/anagram/analyzer/ui/screen/MainScreen.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/screen/MainScreen.kt
@@ -290,7 +290,7 @@ fun MainScreenContent(
                 .fillMaxWidth()
                 .testTag("quiz_button"),
         ) {
-            Text("🎯 クイズモード")
+            Text("← クイズにもどる")
         }
 
         TextButton(

--- a/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -100,7 +101,10 @@ fun QuizScreenContent(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            TextButton(onClick = onNavigateBack) {
+            TextButton(
+                onClick = onNavigateBack,
+                modifier = Modifier.testTag("quiz_to_analysis_button"),
+            ) {
                 Text("🔍 解析モード")
             }
             Text(

--- a/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
+++ b/android/app/src/main/java/com/anagram/analyzer/ui/screen/QuizScreen.kt
@@ -101,7 +101,7 @@ fun QuizScreenContent(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             TextButton(onClick = onNavigateBack) {
-                Text("← もどる")
+                Text("🔍 解析モード")
             }
             Text(
                 text = "クイズモード",


### PR DESCRIPTION
## 概要

Issue #12「クイズモードをメインコンテンツとし、解析モードをオプショナル化」の第一歩として、ナビゲーション構造を変更します。

## 変更内容

起動時のデフォルト画面をクイズモードに変更し、解析モードをオプショナルなサブ機能として位置付けます。

| ファイル | 変更 |
|---------|------|
| `MainActivity.kt` | `showQuiz` の初期値を `false` → `true` に変更（起動時にクイズモードを表示） |
| `QuizScreen.kt` | `← もどる` → `🔍 解析モード` に変更（解析モードへの導線を明示） |
| `MainScreen.kt` | `🎯 クイズモード` → `← クイズにもどる` に変更（メインへ戻る意味に変更） |

## ナビゲーション変更前後

**変更前:**
```
起動 → 解析モード（メイン）→ [🎯 クイズモード] → クイズモード → [← もどる]
```

**変更後:**
```
起動 → クイズモード（メイン）→ [🔍 解析モード] → 解析モード → [← クイズにもどる]
```

## テスト計画

- [ ] アプリ起動時にクイズモードが最初に表示される
- [ ] `🔍 解析モード` ボタンで解析モードへ遷移できる
- [ ] 解析モードから `← クイズにもどる` ボタンでクイズモードへ戻れる
- [ ] アプリ再起動後もクイズモードがスタート画面になっている

## 関連 Issue

Refs #12（ナビゲーション変更の部分。Issue #12 全体は後続PRで対応）

https://claude.ai/code/session_01FSo22sq2UUvfBPtuj7DCHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSo22sq2UUvfBPtuj7DCHW)_