### PR TITLE
fix(android): compileSdk を 36 → 37 に更新

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
     namespace = "com.anagram.analyzer"
-    compileSdk = 36
+    compileSdk = 37
     val releaseStoreFilePath =
         providers.gradleProperty("ANDROID_SIGNING_STORE_FILE").orNull
             ?: providers.environmentVariable("ANDROID_SIGNING_STORE_FILE").orNull

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+org.gradle.java.installations.paths=C:\\Program Files\\Microsoft\\jdk-17.0.19.10-hotspot,C:\\Program Files\\Android\\openjdk\\jdk-21.0.8

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-org.gradle.java.installations.paths=C:\\Program Files\\Microsoft\\jdk-17.0.19.10-hotspot,C:\\Program Files\\Android\\openjdk\\jdk-21.0.8


### PR DESCRIPTION
## Summary

- `android/app/build.gradle.kts` の `compileSdk` を `36` → `37` に更新
- `androidx.core:core-ktx 1.19.0`（PR#78 で更新予定）が `compileSdk >= 37` を要求するため対応

## Background

PR#78（Renovate による `core-ktx 1.18.0 → 1.19.0` 更新）で CI が全落ちしていた。  
原因は `androidx.core:core:1.19.0` / `core-ktx:1.19.0` が `compileSdk >= 37` を要求するのに対し、プロジェクトが `compileSdk = 36` のままだったため。

本 PR をマージ後、PR#78 をマージすることで CI が通る。

## Notes

- `targetSdk` は `34` のまま（`compileSdk` と独立して変更可能）
- ローカル開発環境のセットアップとして Android SDK `platforms;android-37.0` のインストールが必要

## Test plan

- [ ] CI (Android Build / Android Unit Test / Android UI Test) がすべてグリーンになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)